### PR TITLE
Leaderboard

### DIFF
--- a/api/src/api/models/strive.py
+++ b/api/src/api/models/strive.py
@@ -177,8 +177,8 @@ class LeaderboardEntry(BaseModel):
     rank: int = Field(..., description="Rank on the leaderboard.", example=1)
     user_pid: int = Field(..., description="User pid for this entry.", example=730611076)
     username: str = Field(..., description="Display name for the user.", example="student1")
-    score: float = Field(..., description="Score as percentage (0-100).", example=92.5)
-    accuracy: float = Field(..., description="Accuracy as a fraction (0-1).", example=0.925)
+    score: float = Field(..., description="Total score across daily challenges (sum of percentages).", example=185.0)
+    accuracy: float = Field(..., description="Average percentage as a fraction (0-1).", example=0.925)
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/api/src/api/models/strive.py
+++ b/api/src/api/models/strive.py
@@ -150,3 +150,49 @@ class QuizSubmitResponse(BaseModel):
     )
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class QuizResultsResponse(BaseModel):
+    """Response for retrieving the final quiz results with summary feedback."""
+
+    id: int = Field(..., description="Quiz submission id.", example=101)
+    score: float = Field(..., description="Score as percentage (0-100).", example=80.0)
+    correct_count: int = Field(..., description="Number of correct answers.", example=4)
+    total_count: int = Field(..., description="Total number of questions.", example=5)
+    finished_at: datetime = Field(
+        ..., description="UTC timestamp when grading completed.", example="2026-04-15T12:05:00Z"
+    )
+    feedback_summary: Optional[str] = Field(
+        default=None,
+        description="AI-generated summary feedback for the submission.",
+        example="Strong grasp of loops; revisit list indexing.",
+    )
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class LeaderboardEntry(BaseModel):
+    """Single leaderboard entry for daily practice results."""
+
+    rank: int = Field(..., description="Rank on the leaderboard.", example=1)
+    user_pid: int = Field(..., description="User pid for this entry.", example=730611076)
+    username: str = Field(..., description="Display name for the user.", example="student1")
+    score: float = Field(..., description="Score as percentage (0-100).", example=92.5)
+    accuracy: float = Field(..., description="Accuracy as a fraction (0-1).", example=0.925)
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class LeaderboardResponse(BaseModel):
+    """Response for retrieving the daily practice leaderboard."""
+
+    course_id: int = Field(..., description="Course id for the leaderboard.", example=42)
+    updated_at: datetime = Field(
+        ..., description="UTC timestamp when the leaderboard was last updated.", example="2026-04-15T12:05:00Z"
+    )
+    entries: List[LeaderboardEntry] = Field(..., description="Top leaderboard entries.")
+    current_user: Optional[LeaderboardEntry] = Field(
+        default=None, description="Current user entry, if they are ranked."
+    )
+
+    model_config = ConfigDict(from_attributes=True)

--- a/api/src/api/routes/strive_router.py
+++ b/api/src/api/routes/strive_router.py
@@ -2,14 +2,18 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Body, HTTPException, Path
+from fastapi import APIRouter, Body, HTTPException, Path, Query
+from learnwithai.interfaces.jobs import JobUpdate
+from learnwithai_jobqueue.rabbitmq_job_notifier import RabbitMQJobNotifier
 from starlette.status import HTTP_201_CREATED
 
-from api.di import ActivityByPathDI, AuthenticatedUserDI, StriveServiceDI
+from api.di import ActivityByPathDI, AuthenticatedUserDI, SettingsDI, StriveServiceDI
 from api.models.strive import (
+    LeaderboardResponse,
     QuizCreateRequest,
     QuizCreateResponse,
     QuizQuestionsResponse,
+    QuizResultsResponse,
     QuizSubmitRequest,
     QuizSubmitResponse,
 )
@@ -70,14 +74,66 @@ def submit_quiz(
     body: Annotated[QuizSubmitRequest, Body(...)],
     subject: AuthenticatedUserDI,
     strive_svc: StriveServiceDI,
+    settings: SettingsDI,
 ) -> QuizSubmitResponse:
     if strive_svc is None:
         raise HTTPException(status_code=501, detail="StriveService not wired.")
     try:
         # Convert Pydantic DTOs to plain dicts for the in-memory service implementation
         answers = [a.model_dump() for a in body.answers]
-        return QuizSubmitResponse.model_validate(
+        response = QuizSubmitResponse.model_validate(
             strive_svc.submit_quiz(subject=subject, submission_id=quiz_submission_id, answers=answers)
         )
+        course_id = strive_svc.get_submission_course_id(subject=subject, submission_id=quiz_submission_id)
+        notifier = RabbitMQJobNotifier(settings.effective_rabbitmq_url)
+        notifier.notify(
+            JobUpdate(
+                job_id=quiz_submission_id,
+                course_id=course_id,
+                user_id=subject.pid,
+                kind="daily_practice_leaderboard",
+                status="updated",
+            )
+        )
+        notifier.close()
+        return response
     except KeyError:
         raise HTTPException(status_code=404, detail="Quiz submission not found")
+
+
+@router.get(
+    "/quizzes/{quiz_submission_id}/results",
+    response_model=QuizResultsResponse,
+    summary="Get final quiz results with summary feedback",
+)
+def get_quiz_results(
+    subject: AuthenticatedUserDI,
+    quiz_submission_id: Annotated[int, Path(...)],
+    strive_svc: StriveServiceDI,
+) -> QuizResultsResponse:
+    if strive_svc is None:
+        raise HTTPException(status_code=501, detail="StriveService not wired.")
+    try:
+        return QuizResultsResponse.model_validate(
+            strive_svc.get_results(subject=subject, submission_id=quiz_submission_id)
+        )
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Quiz results not found")
+
+
+@router.get(
+    "/daily-practice/leaderboard",
+    response_model=LeaderboardResponse,
+    summary="Get the daily practice leaderboard",
+)
+def get_leaderboard(
+    subject: AuthenticatedUserDI,
+    course_id: Annotated[int, Query(...)],
+    strive_svc: StriveServiceDI,
+    limit: int = Query(10, ge=1, le=100),
+) -> LeaderboardResponse:
+    if strive_svc is None:
+        raise HTTPException(status_code=501, detail="StriveService not wired.")
+    return LeaderboardResponse.model_validate(
+        strive_svc.get_leaderboard(subject=subject, course_id=course_id, limit=limit)
+    )

--- a/api/src/api/routes/strive_router.py
+++ b/api/src/api/routes/strive_router.py
@@ -85,6 +85,7 @@ def submit_quiz(
             strive_svc.submit_quiz(subject=subject, submission_id=quiz_submission_id, answers=answers)
         )
         course_id = strive_svc.get_submission_course_id(subject=subject, submission_id=quiz_submission_id)
+        rank_snapshot = strive_svc.get_leaderboard_rank_snapshot(subject=subject, course_id=course_id)
         notifier = RabbitMQJobNotifier(settings.effective_rabbitmq_url)
         notifier.notify(
             JobUpdate(
@@ -93,6 +94,7 @@ def submit_quiz(
                 user_id=subject.pid,
                 kind="daily_practice_leaderboard",
                 status="updated",
+                metadata=rank_snapshot,
             )
         )
         notifier.close()

--- a/api/test/routes/test_strive_leaderboard.py
+++ b/api/test/routes/test_strive_leaderboard.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+
+def _extract_token_from_redirect(resp) -> str | None:
+    full = str(resp.url)
+    if "token=" in full:
+        return parse_qs(urlparse(full).query).get("token", [None])[0]
+    for h in getattr(resp, "history", []):
+        if "token=" in str(h.url):
+            return parse_qs(urlparse(str(h.url)).query).get("token", [None])[0]
+    return None
+
+
+@pytest.mark.integration
+def test_leaderboard_uses_seeded_scores(client) -> None:
+    r = client.post("/api/dev/reset-db")
+    assert r.status_code == 200
+
+    r = client.get("/api/dev/users")
+    assert r.status_code == 200
+    users = r.json()
+    assert users, "expected seeded users"
+
+    student = next((u for u in users if u.get("onyen") == "student"), users[0])
+    pid = student["pid"]
+
+    r = client.get(f"/api/auth/as/{pid}")
+    token = _extract_token_from_redirect(r)
+    assert token is not None
+    headers = {"Authorization": f"Bearer {token}"}
+
+    r = client.get("/api/courses", headers=headers)
+    assert r.status_code == 200
+    courses = r.json()
+    assert courses, "no courses seeded"
+    course = courses[0]
+
+    r = client.get(f"/api/daily-practice/leaderboard?course_id={course['id']}", headers=headers)
+    assert r.status_code == 200
+    data = r.json()
+
+    entries = data["entries"]
+    assert entries, "expected leaderboard entries"
+
+    student_entry = next((e for e in entries if e["user_pid"] == pid), None)
+    assert student_entry is not None
+    assert student_entry["score"] == 170.0
+    assert student_entry["accuracy"] == pytest.approx(0.85, abs=1e-6)

--- a/api/test/routes/test_strive_router_edges.py
+++ b/api/test/routes/test_strive_router_edges.py
@@ -1,10 +1,80 @@
-from typing import Any
+from datetime import datetime, timezone
+from typing import Any, cast
 
+import pytest
 from fastapi import HTTPException
 from learnwithai.config import Settings
 
+from api.di import AuthenticatedUserDI
 from api.models.strive import QuizCreateRequest, QuizSubmitRequest
-from api.routes.strive_router import get_quiz, start_quiz, submit_quiz
+from api.routes.strive_router import get_leaderboard, get_quiz, get_quiz_results, start_quiz, submit_quiz
+
+
+def test_submit_quiz_success_publishes_job_update(monkeypatch: pytest.MonkeyPatch) -> None:
+    import importlib
+
+    strive_router_module = importlib.import_module("api.routes.strive_router")
+
+    subject = cast(AuthenticatedUserDI, DummyUser(123))
+    body = QuizSubmitRequest.model_validate({"answers": [{"question_id": 1, "selected_choice_id": 1}]})
+
+    captured: dict[str, Any] = {}
+
+    class DummyNotifier:
+        def __init__(self, url: str) -> None:
+            captured["url"] = url
+            captured["closed"] = False
+
+        def notify(self, update: Any) -> None:
+            captured["update"] = update
+
+        def close(self) -> None:
+            captured["closed"] = True
+
+    monkeypatch.setattr(strive_router_module, "RabbitMQJobNotifier", DummyNotifier)
+
+    class WorkingService:
+        def submit_quiz(self, *a: Any, **k: Any) -> dict[str, Any]:
+            submission_id = int(k.get("submission_id") or a[1])
+            return {
+                "id": submission_id,
+                "score": 100.0,
+                "correct_count": 1,
+                "total_count": 1,
+                "feedback": [
+                    {
+                        "question_id": 1,
+                        "correct": True,
+                        "correct_choice_id": 1,
+                        "explanation": "ok",
+                    }
+                ],
+                "finished_at": datetime.now(timezone.utc),
+            }
+
+        def get_submission_course_id(self, *a: Any, **k: Any) -> int:
+            return 42
+
+        def get_leaderboard_rank_snapshot(self, *a: Any, **k: Any) -> dict[str, Any]:
+            return {"rank": 1, "score": 100.0, "accuracy": 1.0, "attempt_count": 1}
+
+    response = submit_quiz(
+        quiz_submission_id=1,
+        body=body,
+        subject=subject,
+        strive_svc=WorkingService(),  # type: ignore[arg-type]
+        settings=Settings(),
+    )
+
+    assert response.id == 1
+    update = captured["update"]
+    assert update.job_id == 1
+    assert update.course_id == 42
+    assert update.user_id == 123
+    assert update.kind == "daily_practice_leaderboard"
+    assert update.status == "updated"
+    assert update.metadata is not None
+    assert captured["closed"] is True
 
 
 class DummyActivity:
@@ -26,6 +96,12 @@ class FailingService:
 
     def submit_quiz(self, *a: Any, **k: Any) -> None:
         raise KeyError("no quiz")
+
+    def get_results(self, *a: Any, **k: Any) -> None:
+        raise KeyError("no results")
+
+    def get_leaderboard(self, *a: Any, **k: Any) -> None:
+        raise KeyError("no leaderboard")
 
 
 def test_start_quiz_unwired_raises_501() -> None:
@@ -51,7 +127,7 @@ def test_start_quiz_keyerror_converted_to_404() -> None:
 
 
 def test_get_and_submit_keyerror_converted_to_404() -> None:
-    subject = DummyUser(123)
+    subject = cast(AuthenticatedUserDI, DummyUser(123))
     try:
         get_quiz(quiz_submission_id=999, subject=subject, strive_svc=FailingService())  # type: ignore[arg-type]
         raise AssertionError("expected HTTPException")
@@ -60,7 +136,7 @@ def test_get_and_submit_keyerror_converted_to_404() -> None:
 
 
 def test_get_and_submit_unwired_raise_501() -> None:
-    subject = DummyUser(123)
+    subject = cast(AuthenticatedUserDI, DummyUser(123))
     try:
         get_quiz(quiz_submission_id=1, subject=subject, strive_svc=None)  # type: ignore[arg-type]
         raise AssertionError("expected HTTPException")
@@ -92,3 +168,44 @@ def test_get_and_submit_unwired_raise_501() -> None:
         raise AssertionError("expected HTTPException")
     except HTTPException as e:
         assert e.status_code == 404
+
+
+def test_get_quiz_results_unwired_raises_501() -> None:
+    subject = cast(AuthenticatedUserDI, DummyUser(123))
+    with pytest.raises(HTTPException) as excinfo:
+        get_quiz_results(subject=subject, quiz_submission_id=1, strive_svc=None)  # type: ignore[arg-type]
+    assert excinfo.value.status_code == 501
+
+
+def test_get_quiz_results_keyerror_converted_to_404() -> None:
+    subject = cast(AuthenticatedUserDI, DummyUser(123))
+    with pytest.raises(HTTPException) as excinfo:
+        get_quiz_results(subject=subject, quiz_submission_id=999, strive_svc=FailingService())  # type: ignore[arg-type]
+    assert excinfo.value.status_code == 404
+
+
+def test_get_quiz_results_success_returns_model() -> None:
+    subject = cast(AuthenticatedUserDI, DummyUser(123))
+
+    class ResultsService:
+        def get_results(self, *a: Any, **k: Any) -> dict[str, Any]:
+            submission_id = int(k.get("submission_id") or a[1])
+            return {
+                "id": submission_id,
+                "score": 100.0,
+                "correct_count": 1,
+                "total_count": 1,
+                "finished_at": datetime.now(timezone.utc),
+                "feedback_summary": "ok",
+            }
+
+    result = get_quiz_results(subject=subject, quiz_submission_id=1, strive_svc=ResultsService())  # type: ignore[arg-type]
+    assert result.id == 1
+    assert result.score == 100.0
+
+
+def test_get_leaderboard_unwired_raises_501() -> None:
+    subject = cast(AuthenticatedUserDI, DummyUser(123))
+    with pytest.raises(HTTPException) as excinfo:
+        get_leaderboard(subject=subject, course_id=1, strive_svc=None, limit=10)  # type: ignore[arg-type]
+    assert excinfo.value.status_code == 501

--- a/api/test/routes/test_strive_router_edges.py
+++ b/api/test/routes/test_strive_router_edges.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from fastapi import HTTPException
+from learnwithai.config import Settings
 
 from api.models.strive import QuizCreateRequest, QuizSubmitRequest
 from api.routes.strive_router import get_quiz, start_quiz, submit_quiz
@@ -68,14 +69,26 @@ def test_get_and_submit_unwired_raise_501() -> None:
 
     body = QuizSubmitRequest.model_validate({"answers": []})
     try:
-        submit_quiz(quiz_submission_id=1, body=body, subject=subject, strive_svc=None)  # type: ignore[arg-type]
+        submit_quiz(
+            quiz_submission_id=1,
+            body=body,
+            subject=subject,
+            strive_svc=None,  # type: ignore[arg-type]
+            settings=Settings(),
+        )
         raise AssertionError("expected HTTPException")
     except HTTPException as e:
         assert e.status_code == 501
 
     body = QuizSubmitRequest.model_validate({"answers": []})
     try:
-        submit_quiz(quiz_submission_id=999, body=body, subject=subject, strive_svc=FailingService())  # type: ignore[arg-type]
+        submit_quiz(
+            quiz_submission_id=999,
+            body=body,
+            subject=subject,
+            strive_svc=FailingService(),  # type: ignore[arg-type]
+            settings=Settings(),
+        )
         raise AssertionError("expected HTTPException")
     except HTTPException as e:
         assert e.status_code == 404

--- a/packages/learnwithai-core/src/learnwithai/dev_data.py
+++ b/packages/learnwithai-core/src/learnwithai/dev_data.py
@@ -16,6 +16,7 @@ from .tables.activity import Activity, ActivityType
 from .tables.async_job import AsyncJob, AsyncJobStatus
 from .tables.course import Course, Term
 from .tables.membership import Membership, MembershipState, MembershipType
+from .tables.strive import StriveActivity, StriveQuestionSet, StriveSubmission
 from .tables.submission import Submission
 from .tables.user import User
 from .tools.jokes.tables import Joke
@@ -197,4 +198,122 @@ def seed(session: Session) -> None:
         async_job_id=iyow_feedback_job.id,
     )
     session.add(iyow_submission_detail)
+    session.flush()
+
+    # --- Strive Activity ---
+    strive_activity_base = Activity(
+        course_id=course.id,
+        created_by_pid=instructor.pid,
+        type=ActivityType.STRIVE,
+        title="Daily Practice: Python Basics",
+        release_date=datetime(2025, 2, 1, 0, 0, tzinfo=timezone.utc),
+        due_date=datetime(2026, 12, 31, 23, 59, tzinfo=timezone.utc),
+        created_at=datetime(2025, 2, 1, 0, 0, tzinfo=timezone.utc),
+    )
+    session.add(strive_activity_base)
+    session.flush()
+    assert strive_activity_base.id is not None
+
+    strive_detail = StriveActivity(
+        activity_id=strive_activity_base.id,
+        mode="daily",
+        module_name="Module 2: Python Basics",
+        topic="Loops",
+        question_count=5,
+    )
+    session.add(strive_detail)
+    session.flush()
+
+    question_set = StriveQuestionSet(
+        strive_activity_id=strive_detail.id,  # type: ignore[arg-type]
+        questions=[
+            {
+                "question_id": 1,
+                "text": "Which keyword starts a loop?",
+                "choices": [
+                    {"id": 1, "text": "for"},
+                    {"id": 2, "text": "def"},
+                ],
+                "correct_choice_id": 1,
+            }
+        ],
+    )
+    session.add(question_set)
+    session.flush()
+
+    # Student submissions
+    student_submission_a = Submission(
+        activity_id=strive_activity_base.id,
+        student_pid=student.pid,
+        is_active=False,
+        submitted_at=datetime(2025, 2, 2, 9, 0, tzinfo=timezone.utc),
+        created_at=datetime(2025, 2, 2, 9, 0, tzinfo=timezone.utc),
+    )
+    session.add(student_submission_a)
+    session.flush()
+
+    student_strive_a = StriveSubmission(
+        submission_id=student_submission_a.id,  # type: ignore[arg-type]
+        question_set_id=question_set.id,  # type: ignore[arg-type]
+        student_pid=student.pid,
+        submitted_answers={"1": 1},
+        correct_count=4,
+        score=80.0,
+        feedback="Nice progress.",
+        status="submitted",
+        started_at=datetime(2025, 2, 2, 8, 50, tzinfo=timezone.utc),
+        completed_at=datetime(2025, 2, 2, 9, 0, tzinfo=timezone.utc),
+    )
+    session.add(student_strive_a)
+    session.flush()
+
+    student_submission_b = Submission(
+        activity_id=strive_activity_base.id,
+        student_pid=student.pid,
+        is_active=False,
+        submitted_at=datetime(2025, 2, 5, 9, 0, tzinfo=timezone.utc),
+        created_at=datetime(2025, 2, 5, 9, 0, tzinfo=timezone.utc),
+    )
+    session.add(student_submission_b)
+    session.flush()
+
+    student_strive_b = StriveSubmission(
+        submission_id=student_submission_b.id,  # type: ignore[arg-type]
+        question_set_id=question_set.id,  # type: ignore[arg-type]
+        student_pid=student.pid,
+        submitted_answers={"1": 1},
+        correct_count=5,
+        score=90.0,
+        feedback="Great work!",
+        status="submitted",
+        started_at=datetime(2025, 2, 5, 8, 50, tzinfo=timezone.utc),
+        completed_at=datetime(2025, 2, 5, 9, 0, tzinfo=timezone.utc),
+    )
+    session.add(student_strive_b)
+    session.flush()
+
+    # TA submission for leaderboard variety
+    ta_submission = Submission(
+        activity_id=strive_activity_base.id,
+        student_pid=ta.pid,
+        is_active=False,
+        submitted_at=datetime(2025, 2, 3, 9, 0, tzinfo=timezone.utc),
+        created_at=datetime(2025, 2, 3, 9, 0, tzinfo=timezone.utc),
+    )
+    session.add(ta_submission)
+    session.flush()
+
+    ta_strive = StriveSubmission(
+        submission_id=ta_submission.id,  # type: ignore[arg-type]
+        question_set_id=question_set.id,  # type: ignore[arg-type]
+        student_pid=ta.pid,
+        submitted_answers={"1": 1},
+        correct_count=5,
+        score=95.0,
+        feedback="Excellent consistency.",
+        status="submitted",
+        started_at=datetime(2025, 2, 3, 8, 50, tzinfo=timezone.utc),
+        completed_at=datetime(2025, 2, 3, 9, 0, tzinfo=timezone.utc),
+    )
+    session.add(ta_strive)
     session.flush()

--- a/packages/learnwithai-core/src/learnwithai/interfaces/jobs.py
+++ b/packages/learnwithai-core/src/learnwithai/interfaces/jobs.py
@@ -4,7 +4,7 @@
 """Contracts for serializable background jobs and their handlers."""
 
 from abc import ABC
-from typing import Protocol, TypeVar, runtime_checkable
+from typing import Any, Protocol, TypeVar, runtime_checkable
 
 from pydantic import BaseModel
 
@@ -57,6 +57,7 @@ class JobUpdate(BaseModel):
     user_id: int
     kind: str
     status: str
+    metadata: dict[str, Any] | None = None
 
 
 @runtime_checkable

--- a/packages/learnwithai-core/src/learnwithai/repositories/strive_repository.py
+++ b/packages/learnwithai-core/src/learnwithai/repositories/strive_repository.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from learnwithai.repositories.base_repository import BaseRepository
+from learnwithai.tables.activity import Activity, ActivityType
 from learnwithai.tables.strive import QuizAnswer, QuizQuestion, QuizSubmission
+from learnwithai.tables.submission import Submission
+from learnwithai.tables.user import User
+from sqlalchemy import func
+from sqlmodel import select
 
 
 class StriveRepository(BaseRepository[QuizSubmission, int]):
@@ -32,3 +37,47 @@ class StriveRepository(BaseRepository[QuizSubmission, int]):
 
     def update_submission(self, submission: QuizSubmission) -> QuizSubmission:
         return self.update(submission)
+
+    def get_leaderboard_stats(self, course_id: int) -> list[dict[str, Any]]:
+        """Aggregate total scores and attempt counts for a course.
+
+        Args:
+            course_id: The course identifier to scope the leaderboard.
+
+        Returns:
+            A list of dicts containing user metadata, total score, and attempt count.
+        """
+        stmt = (
+            select(
+                User.pid,
+                User.onyen,
+                User.name,
+                func.sum(QuizSubmission.score).label("total_score"),
+                func.count(QuizSubmission.id).label("attempt_count"),
+            )
+            .join(Submission, Submission.id == QuizSubmission.submission_id)
+            .join(Activity, Activity.id == Submission.activity_id)
+            .join(User, User.pid == QuizSubmission.student_pid)
+            .where(
+                Activity.course_id == course_id,
+                Activity.type == ActivityType.STRIVE,
+                QuizSubmission.score.is_not(None),
+            )
+            .group_by(User.pid, User.onyen, User.name)
+            .order_by(func.sum(QuizSubmission.score).desc())
+        )
+
+        rows = self._session.exec(stmt).all()
+        results: list[dict[str, Any]] = []
+        for row in rows:
+            total_score = float(row.total_score or 0.0)
+            attempt_count = int(row.attempt_count or 0)
+            results.append(
+                {
+                    "user_pid": int(row.pid),
+                    "username": row.onyen or row.name,
+                    "total_score": total_score,
+                    "attempt_count": attempt_count,
+                }
+            )
+        return results

--- a/packages/learnwithai-core/src/learnwithai/services/strive_service.py
+++ b/packages/learnwithai-core/src/learnwithai/services/strive_service.py
@@ -75,6 +75,7 @@ class StriveService:
             "submission": {
                 "id": submission_id,
                 "activity_id": activity.id,
+                "course_id": activity.course_id,
                 "student_pid": subject.pid,
                 "status": "in_progress",
                 "started_at": started_at,
@@ -151,13 +152,75 @@ class StriveService:
         finished_at = datetime.now(timezone.utc)
 
         # update store
-        data["submission"].update({"status": "submitted", "finished_at": finished_at})
-
-        return {
+        results = {
             "id": submission_id,
             "score": score,
             "correct_count": correct_count,
             "total_count": total,
             "feedback": feedback,
             "finished_at": finished_at,
+            "feedback_summary": "Summary feedback is not yet available.",
+        }
+
+        data["submission"].update({"status": "submitted", "finished_at": finished_at})
+        data["results"] = results
+
+        return results
+
+    def get_results(self, subject: User, submission_id: int) -> dict[str, Any]:
+        data = _QUIZ_STORE.get(int(submission_id))
+        if data is None:
+            raise KeyError("quiz not found")
+        results = data.get("results")
+        if results is None:
+            raise KeyError("quiz results not found")
+        return results
+
+    def get_submission_course_id(self, subject: User, submission_id: int) -> int:
+        data = _QUIZ_STORE.get(int(submission_id))
+        if data is None:
+            raise KeyError("quiz not found")
+        submission = data.get("submission")
+        if submission is None or submission.get("course_id") is None:
+            raise KeyError("quiz course not found")
+        return int(submission["course_id"])
+
+    def get_leaderboard(self, subject: User, course_id: int, limit: int = 10) -> dict[str, Any]:
+        leaderboard: dict[int, dict[str, Any]] = {}
+        updated_at = datetime.now(timezone.utc)
+
+        for data in _QUIZ_STORE.values():
+            submission = data.get("submission")
+            results = data.get("results")
+            if submission is None or results is None:
+                continue
+
+            student_pid = int(submission.get("student_pid"))
+            score = float(results.get("score", 0.0))
+            correct_count = int(results.get("correct_count", 0))
+            total_count = int(results.get("total_count", 0))
+            accuracy = (correct_count / total_count) if total_count > 0 else 0.0
+
+            existing = leaderboard.get(student_pid)
+            if existing is None or score > existing["score"]:
+                leaderboard[student_pid] = {
+                    "user_pid": student_pid,
+                    "username": f"student-{student_pid}",
+                    "score": score,
+                    "accuracy": accuracy,
+                }
+
+        entries = sorted(leaderboard.values(), key=lambda entry: entry["score"], reverse=True)
+        ranked_entries = []
+        for index, entry in enumerate(entries, start=1):
+            ranked_entries.append({"rank": index, **entry})
+
+        limited_entries = ranked_entries[: max(limit, 0)]
+        current_user = next((e for e in ranked_entries if e["user_pid"] == subject.pid), None)
+
+        return {
+            "course_id": course_id,
+            "updated_at": updated_at,
+            "entries": limited_entries,
+            "current_user": current_user,
         }

--- a/packages/learnwithai-core/src/learnwithai/services/strive_service.py
+++ b/packages/learnwithai-core/src/learnwithai/services/strive_service.py
@@ -5,8 +5,9 @@ from datetime import datetime, timezone
 from itertools import count
 from typing import Any, List
 
-from learnwithai.tables.activity import Activity
-from learnwithai.tables.user import User
+from ..repositories.strive_repository import StriveRepository
+from ..tables.activity import Activity
+from ..tables.user import User
 
 # Simple in-memory store for dev/testing so the endpoints work without DB migrations.
 _NEXT_ID = count(1)
@@ -34,9 +35,13 @@ class StriveService:
     suitable for production.
     """
 
-    def __init__(self, *_args: object, **_kwargs: object) -> None:
-        # Accept repository injection but do not require it for the dev shim
-        return None
+    def __init__(self, strive_repo: StriveRepository | None = None) -> None:
+        """Initialize the Strive service.
+
+        Args:
+            strive_repo: Repository used for persistent Strive data.
+        """
+        self._strive_repo = strive_repo
 
     def start_quiz(self, subject: User, activity: Activity, options: Any | None = None) -> _QuizHandle:
         """Create an in-memory quiz and return a lightweight handle.
@@ -75,7 +80,7 @@ class StriveService:
             "submission": {
                 "id": submission_id,
                 "activity_id": activity.id,
-                "course_id": activity.course_id,
+                "course_id": getattr(activity, "course_id", None),
                 "student_pid": subject.pid,
                 "status": "in_progress",
                 "started_at": started_at,
@@ -186,34 +191,30 @@ class StriveService:
         return int(submission["course_id"])
 
     def get_leaderboard(self, subject: User, course_id: int, limit: int = 10) -> dict[str, Any]:
-        leaderboard: dict[int, dict[str, Any]] = {}
         updated_at = datetime.now(timezone.utc)
+        if self._strive_repo is None:
+            return {
+                "course_id": course_id,
+                "updated_at": updated_at,
+                "entries": [],
+                "current_user": None,
+            }
 
-        for data in _QUIZ_STORE.values():
-            submission = data.get("submission")
-            results = data.get("results")
-            if submission is None or results is None:
-                continue
-
-            student_pid = int(submission.get("student_pid"))
-            score = float(results.get("score", 0.0))
-            correct_count = int(results.get("correct_count", 0))
-            total_count = int(results.get("total_count", 0))
-            accuracy = (correct_count / total_count) if total_count > 0 else 0.0
-
-            existing = leaderboard.get(student_pid)
-            if existing is None or score > existing["score"]:
-                leaderboard[student_pid] = {
-                    "user_pid": student_pid,
-                    "username": f"student-{student_pid}",
-                    "score": score,
-                    "accuracy": accuracy,
+        stats = self._strive_repo.get_leaderboard_stats(course_id)
+        ranked_entries: list[dict[str, Any]] = []
+        for index, entry in enumerate(stats, start=1):
+            total_score = float(entry["total_score"])
+            attempt_count = int(entry["attempt_count"])
+            percentage = (total_score / (attempt_count * 100.0)) if attempt_count > 0 else 0.0
+            ranked_entries.append(
+                {
+                    "rank": index,
+                    "user_pid": entry["user_pid"],
+                    "username": entry["username"],
+                    "score": total_score,
+                    "accuracy": percentage,
                 }
-
-        entries = sorted(leaderboard.values(), key=lambda entry: entry["score"], reverse=True)
-        ranked_entries = []
-        for index, entry in enumerate(entries, start=1):
-            ranked_entries.append({"rank": index, **entry})
+            )
 
         limited_entries = ranked_entries[: max(limit, 0)]
         current_user = next((e for e in ranked_entries if e["user_pid"] == subject.pid), None)
@@ -224,3 +225,32 @@ class StriveService:
             "entries": limited_entries,
             "current_user": current_user,
         }
+
+    def get_leaderboard_rank_snapshot(self, subject: User, course_id: int) -> dict[str, Any] | None:
+        """Return the current user's leaderboard snapshot for a course.
+
+        Args:
+            subject: Authenticated user requesting the snapshot.
+            course_id: Course identifier for the leaderboard.
+
+        Returns:
+            A dict containing rank, score, accuracy, and attempt_count when available.
+        """
+        if self._strive_repo is None:
+            return None
+
+        stats = self._strive_repo.get_leaderboard_stats(course_id)
+        for index, entry in enumerate(stats, start=1):
+            if entry["user_pid"] != subject.pid:
+                continue
+            total_score = float(entry["total_score"])
+            attempt_count = int(entry["attempt_count"])
+            accuracy = (total_score / (attempt_count * 100.0)) if attempt_count > 0 else 0.0
+            return {
+                "rank": index,
+                "score": total_score,
+                "accuracy": accuracy,
+                "attempt_count": attempt_count,
+            }
+
+        return None

--- a/packages/learnwithai-core/test/test_dev_data.py
+++ b/packages/learnwithai-core/test/test_dev_data.py
@@ -43,12 +43,20 @@ def test_seed_creates_three_users_one_course_and_three_memberships() -> None:
     # add_all called twice: once for users, once for memberships
     assert session.add_all.call_count == 2
     # add called: course, joke_job, joke_request, iyow_activity, iyow_detail,
-    #             iyow_feedback_job, iyow_submission, iyow_submission_detail
-    assert session.add.call_count == 8
+    #             iyow_feedback_job, iyow_submission, iyow_submission_detail,
+    #             strive_activity, strive_detail, question_set,
+    #             student_submission_a, student_strive_a,
+    #             student_submission_b, student_strive_b,
+    #             ta_submission, ta_strive
+    assert session.add.call_count == 17
     # flush called: users, course, memberships, joke_job, joke_request,
     #               iyow_activity, iyow_detail, iyow_feedback_job, iyow_submission,
-    #               iyow_submission_detail
-    assert session.flush.call_count == 10
+    #               iyow_submission_detail,
+    #               strive_activity, strive_detail, question_set,
+    #               student_submission_a, student_strive_a,
+    #               student_submission_b, student_strive_b,
+    #               ta_submission, ta_strive
+    assert session.flush.call_count == 19
 
     # Verify users
     users = added[0]
@@ -112,3 +120,8 @@ def test_seed_creates_three_users_one_course_and_three_memberships() -> None:
     iyow_sub_detail = added_single[7]
     assert isinstance(iyow_sub_detail, IyowSubmission)
     assert iyow_sub_detail.async_job_id == iyow_feedback_job.id
+
+    # Verify Strive activity
+    strive_activity = added_single[8]
+    assert isinstance(strive_activity, Activity)
+    assert "Daily Practice" in strive_activity.title


### PR DESCRIPTION
# Title
Implement Strive daily-challenge leaderboard
# Description
- Adds leaderboard support for daily challenge, creates a new leaderboard route, and published job update after quiz submission so users can refresh leaderboard state
# Major Changes
- Add LeaderboardResponse and LeaderboardEntry in strive.py
- Routes: add GET route to retrieve leaderboard and wire quiz endpoints in strive_router.py
- Publish JobUpdate to keep leaderboard accurate in real-time
# Testing
- Added/Updated Tests: unit router edge tests, seeded leaderboard integration test, service tests
# Future Considerations
- Replace notifier construction in the route with DI managed notifier lifecycle
- Consider paging for leaderboard
- Centralize JobUpdate to avoid drift across users
- Replace mock data with real-time user fetching