### PR TITLE
Add LLM-generated daily quiz flow and post-quiz feedback

### DIFF
--- a/api/test/routes/test_strive_llm.py
+++ b/api/test/routes/test_strive_llm.py
@@ -1,0 +1,450 @@
+"""Integration tests for LLM-powered quiz generation in Strive."""
+
+from __future__ import annotations
+
+import json
+from urllib.parse import parse_qs, urlparse
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _extract_token_from_redirect(resp) -> str | None:
+    """Extract JWT token from redirect response."""
+    full = str(resp.url)
+    if "token=" in full:
+        return parse_qs(urlparse(full).query).get("token", [None])[0]
+    for h in getattr(resp, "history", []):
+        if "token=" in str(h.url):
+            return parse_qs(urlparse(str(h.url)).query).get("token", [None])[0]
+    return None
+
+
+@pytest.fixture
+def authenticated_client(client: TestClient) -> TestClient:
+    """Get a TestClient with valid JWT token."""
+    # Reset DB
+    r = client.post("/api/dev/reset-db")
+    assert r.status_code == 200
+
+    # Get user
+    r = client.get("/api/dev/users")
+    assert r.status_code == 200
+    users = r.json()
+    assert users, "expected seeded users"
+    pid = users[0]["pid"]
+
+    # Login to get token
+    r = client.get(f"/api/auth/as/{pid}")
+    token = _extract_token_from_redirect(r)
+    assert token is not None, "Failed to extract token from auth response"
+
+    # Set header for all subsequent requests
+    client.headers = {"Authorization": f"Bearer {token}"}
+    return client
+
+
+@pytest.fixture
+def mock_llm_response() -> list[dict]:
+    """Sample LLM-generated questions response."""
+    return [
+        {
+            "question": "What is Python?",
+            "choices": ["A programming language", "A type of snake", "An editor", "A database"],
+            "correct_choice_index": 0,
+            "explanation": "Python is a high-level programming language known for its simplicity.",
+        },
+        {
+            "question": "What is a function?",
+            "choices": ["A variable", "A reusable block of code", "A loop", "A string"],
+            "correct_choice_index": 1,
+            "explanation": "A function is a reusable block of code that performs a specific task.",
+        },
+        {
+            "question": "Which keyword defines a function in Python?",
+            "choices": ["function", "def", "define", "func"],
+            "correct_choice_index": 1,
+            "explanation": "The 'def' keyword is used to define a function in Python.",
+        },
+    ]
+
+
+@pytest.fixture
+def get_activity(authenticated_client: TestClient):
+    """Helper to get a test activity."""
+    r = authenticated_client.get("/api/courses")
+    assert r.status_code == 200
+    courses = r.json()
+    assert courses, "expected seeded courses"
+    course_id = courses[0]["id"]
+
+    r = authenticated_client.get(f"/api/courses/{course_id}/activities")
+    assert r.status_code == 200
+    activities = r.json()
+    assert activities, "expected seeded activities"
+    activity_id = activities[0]["id"]
+
+    return authenticated_client, activity_id
+
+
+@pytest.mark.integration
+def test_create_quiz_with_llm_success(authenticated_client: TestClient, mock_llm_response: list[dict]) -> None:
+    """Test successful quiz creation with LLM-generated questions."""
+    # Get an activity
+    r = authenticated_client.get("/api/courses")
+    course_id = r.json()[0]["id"]
+
+    r = authenticated_client.get(f"/api/courses/{course_id}/activities")
+    activity_id = r.json()[0]["id"]
+
+    # Mock OpenAI API
+    with patch("learnwithai.services.strive_service.OpenAI") as mock_openai:
+        mock_client = MagicMock()
+        mock_openai.return_value = mock_client
+
+        # Mock the chat completion response
+        mock_completion = MagicMock()
+        mock_completion.choices[0].message.content = json.dumps(mock_llm_response)
+        mock_client.chat.completions.create.return_value = mock_completion
+
+        # Ensure API key is set
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test-key"}):
+            # Step 1: Create quiz with LLM parameters
+            create_response = authenticated_client.post(
+                f"/api/activities/{activity_id}/quizzes",
+                json={
+                    "mode": "module",
+                    "module_name": "Module 2: Python Basics",
+                    "topic": "Functions",
+                    "question_count": 3,
+                },
+            )
+
+            # Assertions on creation
+            assert create_response.status_code == 201
+            quiz_data = create_response.json()
+            assert quiz_data["status"] == "in_progress"
+            assert quiz_data["question_count"] == 3
+            assert quiz_data["mode"] == "module"
+            assert quiz_data["topic"] == "Functions"
+            assert quiz_data["module_name"] == "Module 2: Python Basics"
+            quiz_id = quiz_data["id"]
+
+            # Verify OpenAI was called with correct parameters
+            mock_client.chat.completions.create.assert_called_once()
+            call_args = mock_client.chat.completions.create.call_args
+            prompt = call_args.kwargs["messages"][0]["content"]
+            assert "Functions" in prompt
+            assert "Module 2: Python Basics" in prompt
+            assert "3" in prompt
+
+            # Step 2: Retrieve questions
+            questions_response = authenticated_client.get(f"/api/quizzes/{quiz_id}")
+
+            # Assertions on questions
+            assert questions_response.status_code == 200
+            quiz_questions = questions_response.json()
+            assert quiz_questions["id"] == quiz_id
+            assert len(quiz_questions["questions"]) == 3
+            assert quiz_questions["mode"] == "module"
+
+            # Verify first question structure
+            first_question = quiz_questions["questions"][0]
+            assert first_question["text"] == "What is Python?"
+            assert len(first_question["choices"]) == 4
+            assert first_question["choices"][0]["text"] == "A programming language"
+            assert first_question["question_id"] == 1
+
+
+@pytest.mark.integration
+def test_create_quiz_with_topic_only(authenticated_client: TestClient, mock_llm_response: list[dict]) -> None:
+    """Test quiz creation with only topic specified (no module_name)."""
+    r = authenticated_client.get("/api/courses")
+    course_id = r.json()[0]["id"]
+
+    r = authenticated_client.get(f"/api/courses/{course_id}/activities")
+    activity_id = r.json()[0]["id"]
+
+    with patch("learnwithai.services.strive_service.OpenAI") as mock_openai:
+        mock_client = MagicMock()
+        mock_openai.return_value = mock_client
+
+        mock_completion = MagicMock()
+        mock_completion.choices[0].message.content = json.dumps(mock_llm_response[:2])
+        mock_client.chat.completions.create.return_value = mock_completion
+
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test-key"}):
+            response = authenticated_client.post(
+                f"/api/activities/{activity_id}/quizzes",
+                json={
+                    "mode": "daily",
+                    "topic": "Variables",
+                    "question_count": 2,
+                },
+            )
+
+            assert response.status_code == 201
+            quiz_data = response.json()
+            assert quiz_data["status"] == "in_progress"
+            assert quiz_data["question_count"] == 2
+            assert quiz_data["topic"] == "Variables"
+            assert quiz_data["module_name"] is None
+
+            # Verify prompt includes topic but not module
+            call_args = mock_client.chat.completions.create.call_args
+            prompt = call_args.kwargs["messages"][0]["content"]
+            assert "Variables" in prompt
+
+
+@pytest.mark.integration
+def test_create_quiz_when_llm_api_fails(authenticated_client: TestClient) -> None:
+    """Test graceful fallback when LLM API raises an exception."""
+    r = authenticated_client.get("/api/courses")
+    course_id = r.json()[0]["id"]
+
+    r = authenticated_client.get(f"/api/courses/{course_id}/activities")
+    activity_id = r.json()[0]["id"]
+
+    with patch("learnwithai.services.strive_service.OpenAI") as mock_openai:
+        mock_client = MagicMock()
+        mock_openai.return_value = mock_client
+        # Simulate API error
+        mock_client.chat.completions.create.side_effect = Exception("API rate limit exceeded")
+
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test-key"}):
+            # Should still succeed (fallback to empty questions)
+            response = authenticated_client.post(
+                f"/api/activities/{activity_id}/quizzes",
+                json={"mode": "daily", "question_count": 3},
+            )
+
+            assert response.status_code == 201
+            quiz_data = response.json()
+            quiz_id = quiz_data["id"]
+
+            # Retrieve questions (should have empty or default questions)
+            response = authenticated_client.get(f"/api/quizzes/{quiz_id}")
+            assert response.status_code == 200
+
+
+@pytest.mark.integration
+def test_create_quiz_without_api_key(authenticated_client: TestClient) -> None:
+    """Test that sample/fallback questions are used when no OpenAI API key."""
+    r = authenticated_client.get("/api/courses")
+    course_id = r.json()[0]["id"]
+
+    r = authenticated_client.get(f"/api/courses/{course_id}/activities")
+    activity_id = r.json()[0]["id"]
+
+    # Clear API key
+    with patch.dict("os.environ", {}, clear=True):
+        response = authenticated_client.post(
+            f"/api/activities/{activity_id}/quizzes",
+            json={"mode": "daily", "question_count": 5},
+        )
+
+        assert response.status_code == 201
+        quiz_data = response.json()
+        assert quiz_data["status"] == "in_progress"
+        assert quiz_data["question_count"] == 5
+        quiz_id = quiz_data["id"]
+
+        # Retrieve questions
+        response = authenticated_client.get(f"/api/quizzes/{quiz_id}")
+        assert response.status_code == 200
+        quiz_questions = response.json()
+        assert len(quiz_questions["questions"]) == 5
+
+        # Verify sample questions are used
+        first_question = quiz_questions["questions"][0]
+        assert "Sample question" in first_question["text"]
+
+
+@pytest.mark.integration
+def test_create_quiz_with_malformed_llm_response(authenticated_client: TestClient) -> None:
+    """Test that malformed LLM response is handled gracefully."""
+    r = authenticated_client.get("/api/courses")
+    course_id = r.json()[0]["id"]
+
+    r = authenticated_client.get(f"/api/courses/{course_id}/activities")
+    activity_id = r.json()[0]["id"]
+
+    with patch("learnwithai.services.strive_service.OpenAI") as mock_openai:
+        mock_client = MagicMock()
+        mock_openai.return_value = mock_client
+
+        # Return invalid JSON
+        mock_completion = MagicMock()
+        mock_completion.choices[0].message.content = "invalid json not parseable"
+        mock_client.chat.completions.create.return_value = mock_completion
+
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test-key"}):
+            response = authenticated_client.post(
+                f"/api/activities/{activity_id}/quizzes",
+                json={"mode": "daily", "question_count": 3},
+            )
+
+            # Should still return 201
+            assert response.status_code == 201
+            quiz_id = response.json()["id"]
+
+            # Should not crash on retrieval
+            response = authenticated_client.get(f"/api/quizzes/{quiz_id}")
+            assert response.status_code == 200
+
+
+@pytest.mark.integration
+def test_submit_quiz_with_llm_questions(authenticated_client: TestClient, mock_llm_response: list[dict]) -> None:
+    """Test submitting answers to an LLM-generated quiz."""
+    r = authenticated_client.get("/api/courses")
+    course_id = r.json()[0]["id"]
+
+    r = authenticated_client.get(f"/api/courses/{course_id}/activities")
+    activity_id = r.json()[0]["id"]
+
+    with patch("learnwithai.services.strive_service.OpenAI") as mock_openai:
+        mock_client = MagicMock()
+        mock_openai.return_value = mock_client
+
+        mock_completion = MagicMock()
+        mock_completion.choices[0].message.content = json.dumps(mock_llm_response)
+        mock_client.chat.completions.create.return_value = mock_completion
+
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test-key"}):
+            # Create quiz
+            create_response = authenticated_client.post(
+                f"/api/activities/{activity_id}/quizzes",
+                json={
+                    "mode": "module",
+                    "module_name": "Python Functions",
+                    "question_count": 3,
+                },
+            )
+            quiz_id = create_response.json()["id"]
+
+            # Submit answers
+            submit_response = authenticated_client.post(
+                f"/api/quizzes/{quiz_id}/submit",
+                json={
+                    "answers": [
+                        {"question_id": 1, "selected_choice_id": 1},  # Correct
+                        {"question_id": 2, "selected_choice_id": 2},  # Correct
+                        {"question_id": 3, "selected_choice_id": 2},  # Correct
+                    ]
+                },
+            )
+
+            assert submit_response.status_code == 200
+            submit_data = submit_response.json()
+            assert submit_data["id"] == quiz_id
+            assert len(submit_data["feedback"]) == 3
+
+            # Verify feedback structure
+            for feedback in submit_data["feedback"]:
+                assert "question_id" in feedback
+                assert "correct" in feedback
+                assert "explanation" in feedback
+
+
+@pytest.mark.integration
+def test_enhanced_prompt_with_step_by_step_explanation(authenticated_client: TestClient) -> None:
+    """Test that enhanced prompt generates questions with detailed step-by-step explanations."""
+    r = authenticated_client.get("/api/courses")
+    course_id = r.json()[0]["id"]
+
+    r = authenticated_client.get(f"/api/courses/{course_id}/activities")
+    activity_id = r.json()[0]["id"]
+
+    # Create questions with detailed step-by-step explanations
+    detailed_llm_response = [
+        {
+            "question": "What is the purpose of a function in Python?",
+            "choices": [
+                "To execute code once and discard it",
+                "To organize reusable code into named blocks that can be called multiple times",
+                "To create variables that store data",
+                "To display output on the screen",
+            ],
+            "correct_choice_index": 1,
+            "explanation": (
+                "Step 1: A function is a named block of code. "
+                "Step 2: Functions allow us to write code once and reuse it many times by calling the function name. "
+                "Step 3: This promotes code organization, reduces duplication, and makes programs easier to maintain. "
+                "Therefore, organizing reusable code into named blocks is the core purpose of functions."
+            ),
+        },
+        {
+            "question": "How do you define a function in Python?",
+            "choices": ["Using the 'function' keyword", "Using the 'def' keyword followed by a colon", "Using parentheses only", "Functions cannot be defined"],
+            "correct_choice_index": 1,
+            "explanation": (
+                "Step 1: Python uses the 'def' keyword to define functions. "
+                "Step 2: The syntax is 'def function_name():' with a colon at the end. "
+                "Step 3: The function body is indented below the def line. "
+                "Therefore, the 'def' keyword followed by a colon is the correct Python syntax for function definition."
+            ),
+        },
+    ]
+
+    with patch("learnwithai.services.strive_service.OpenAI") as mock_openai:
+        mock_client = MagicMock()
+        mock_openai.return_value = mock_client
+
+        mock_completion = MagicMock()
+        mock_completion.choices[0].message.content = json.dumps(detailed_llm_response)
+        mock_client.chat.completions.create.return_value = mock_completion
+
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test-key"}):
+            # Create quiz with module and topic context
+            response = authenticated_client.post(
+                f"/api/activities/{activity_id}/quizzes",
+                json={
+                    "mode": "module",
+                    "module_name": "Module 2: Python Basics",
+                    "topic": "Functions",
+                    "question_count": 2,
+                },
+            )
+
+            assert response.status_code == 201
+            quiz_id = response.json()["id"]
+
+            # Verify enhanced prompt was used
+            mock_client.chat.completions.create.assert_called_once()
+            call_args = mock_client.chat.completions.create.call_args
+            prompt = call_args.kwargs["messages"][0]["content"]
+
+            # Verify enhanced prompt features
+            assert "step-by-step" in prompt.lower()
+            assert "learning objective" in prompt.lower() or "core concept" in prompt.lower()
+            assert "misconception" in prompt.lower()
+            assert "Module 2: Python Basics" in prompt
+            assert "Functions" in prompt
+
+            # Get questions
+            questions_response = authenticated_client.get(f"/api/quizzes/{quiz_id}")
+            assert questions_response.status_code == 200
+            quiz_questions = questions_response.json()
+            assert len(quiz_questions["questions"]) == 2
+
+            # Submit answers to retrieve explanations and verify step-by-step content
+            submit_response = authenticated_client.post(
+                f"/api/quizzes/{quiz_id}/submit",
+                json={
+                    "answers": [
+                        {"question_id": 1, "selected_choice_id": 2},  # Correct
+                        {"question_id": 2, "selected_choice_id": 2},  # Correct
+                    ]
+                },
+            )
+
+            assert submit_response.status_code == 200
+            feedback = submit_response.json()
+            assert len(feedback["feedback"]) == 2
+
+            # Verify step-by-step explanations are returned
+            for fb in feedback["feedback"]:
+                explanation = fb.get("explanation", "")
+                assert "Step" in explanation, "Explanation should contain step-by-step content"
+                assert len(explanation) > 100, "Explanation should be detailed (not just one-liner)"

--- a/frontend/src/app/courses/course-detail/student/daily-practice/daily-practice.component.html
+++ b/frontend/src/app/courses/course-detail/student/daily-practice/daily-practice.component.html
@@ -8,7 +8,7 @@
     <mat-card-content class="space-y-2">
       <p class="text-sm font-medium tracking-[0.08em] uppercase opacity-80">Today's Challenge</p>
       <p class="text-base opacity-90">Answer one question at a time and use Next to continue.</p>
-      @if (usingMockData()) {
+      @if (message()) {
         <p class="text-sm opacity-75" role="status">{{ message() }}</p>
       }
     </mat-card-content>
@@ -24,9 +24,41 @@
     <mat-card appearance="outlined">
       <mat-card-content class="space-y-3">
         <p class="text-lg font-semibold">Challenge complete</p>
+        @if (submissionResult(); as result) {
+          <p class="text-sm opacity-80">
+            Score: {{ scorePercent() }}% ({{ result.correct_count }}/{{ result.total_count }}
+            correct)
+          </p>
+        }
         <p class="text-sm opacity-80">
           You answered {{ answeredCount() }} out of {{ totalQuestions() }} questions.
         </p>
+
+        @if (quiz(); as quizData) {
+          <section class="space-y-3" aria-label="Quiz feedback">
+            @for (question of quizData.questions; track question.question_id) {
+              @if (feedbackByQuestionId().get(question.question_id); as feedback) {
+                <article class="rounded-md border p-3">
+                  <p class="text-sm font-semibold">{{ question.text }}</p>
+                  <p class="text-sm opacity-90">
+                    @if (feedback.correct) {
+                      Correct
+                    } @else {
+                      Incorrect
+                    }
+                  </p>
+                  @if (!feedback.correct && feedback.explanation) {
+                    <p class="text-sm opacity-80">{{ feedback.explanation }}</p>
+                  }
+                </article>
+              }
+            }
+          </section>
+        }
+
+        @if (message()) {
+          <p class="text-sm opacity-75" role="status">{{ message() }}</p>
+        }
         <button mat-flat-button color="primary" type="button" (click)="restart()">Try Again</button>
       </mat-card-content>
     </mat-card>
@@ -51,24 +83,28 @@
           }
         </mat-radio-group>
 
-        @if (immediateFeedbackForCurrent()) {
-          <section class="rounded-md border p-3" aria-live="polite">
-            <p class="text-sm font-medium">Immediate Feedback</p>
-            <p class="text-sm opacity-90">{{ immediateFeedbackForCurrent() }}</p>
-          </section>
-        }
-
         <div class="flex justify-end">
           <button
             mat-flat-button
             color="primary"
             type="button"
-            [disabled]="!hasAnsweredCurrent()"
+            [disabled]="!hasAnsweredCurrent() || submitting()"
             (click)="onNext()"
           >
-            {{ nextLabel() }}
+            @if (submitting()) {
+              Submitting...
+            } @else {
+              {{ nextLabel() }}
+            }
           </button>
         </div>
+      </mat-card-content>
+    </mat-card>
+  } @else if (message()) {
+    <mat-card appearance="outlined">
+      <mat-card-content class="space-y-2">
+        <p class="text-lg font-semibold">Quiz unavailable</p>
+        <p class="text-sm opacity-80">{{ message() }}</p>
       </mat-card-content>
     </mat-card>
   }

--- a/frontend/src/app/courses/course-detail/student/daily-practice/daily-practice.component.spec.ts
+++ b/frontend/src/app/courses/course-detail/student/daily-practice/daily-practice.component.spec.ts
@@ -6,12 +6,16 @@
 import { TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { DailyPractice } from './daily-practice.component';
+import { DailyPractice, RECENT_DAILY_SCORES_STORAGE_KEY } from './daily-practice.component';
 import { PageTitleService } from '../../../../page-title.service';
 import { ActivityService } from '../../activities/activity.service';
 import { StriveQuizService } from './strive-quiz.service';
 import { Activity } from '../../../../api/models';
-import { QuizCreateResponse, QuizQuestionsResponse } from './strive-quiz.models';
+import {
+  QuizCreateResponse,
+  QuizQuestionsResponse,
+  QuizSubmitResponse,
+} from './strive-quiz.models';
 
 const flush = () => new Promise((resolve) => setTimeout(resolve));
 
@@ -86,7 +90,33 @@ const fakeQuestionsResponse: QuizQuestionsResponse = {
   ],
 };
 
+const fakeSubmitResponse: QuizSubmitResponse = {
+  id: 101,
+  score: 50,
+  correct_count: 1,
+  total_count: 2,
+  feedback: [
+    {
+      question_id: 1,
+      correct: true,
+      correct_choice_id: 2,
+      explanation: 'def is the Python keyword used to define functions.',
+    },
+    {
+      question_id: 2,
+      correct: false,
+      correct_choice_id: 2,
+      explanation: 'A dictionary stores key-value pairs in Python.',
+    },
+  ],
+  finished_at: '2026-04-20T12:05:00Z',
+};
+
 describe('DailyPractice', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   function setup(
     options: {
       activityList?: Activity[];
@@ -94,6 +124,7 @@ describe('DailyPractice', () => {
       loadActivities?: () => Promise<Activity[]>;
       startQuizResponse?: QuizCreateResponse;
       getQuizResponse?: QuizQuestionsResponse;
+      submitQuizResponse?: QuizSubmitResponse;
     } = {},
   ) {
     const mockPageTitle = {
@@ -111,7 +142,7 @@ describe('DailyPractice', () => {
     const mockQuizService = {
       startQuiz: vi.fn(() => Promise.resolve(options.startQuizResponse ?? fakeCreateResponse)),
       getQuiz: vi.fn(() => Promise.resolve(options.getQuizResponse ?? fakeQuestionsResponse)),
-      submitQuiz: vi.fn(),
+      submitQuiz: vi.fn(() => Promise.resolve(options.submitQuizResponse ?? fakeSubmitResponse)),
     };
 
     const mockRoute = {
@@ -152,7 +183,7 @@ describe('DailyPractice', () => {
     expect(fixture.nativeElement.textContent).toContain('Which keyword defines a function?');
   });
 
-  it('should show immediate feedback after selecting an answer and move to next question', async () => {
+  it('should move to next question after selecting an answer', async () => {
     const { fixture } = setup();
     await flush();
     fixture.detectChanges();
@@ -163,8 +194,6 @@ describe('DailyPractice', () => {
       component as unknown as { selectChoice: (questionId: number, choiceId: number) => void }
     ).selectChoice(1, 2);
     fixture.detectChanges();
-
-    expect(fixture.nativeElement.textContent).toContain('Immediate Feedback');
 
     (
       component as unknown as {
@@ -201,7 +230,6 @@ describe('DailyPractice', () => {
       currentChoices: () => unknown[];
       hasAnsweredCurrent: () => boolean;
       selectedChoiceForCurrent: () => unknown;
-      immediateFeedbackForCurrent: () => string;
       nextLabel: () => string;
       answeredCount: () => number;
     };
@@ -211,7 +239,6 @@ describe('DailyPractice', () => {
     expect(state.currentChoices()).toEqual([]);
     expect(state.hasAnsweredCurrent()).toBe(false);
     expect(state.selectedChoiceForCurrent()).toBeNull();
-    expect(state.immediateFeedbackForCurrent()).toBe('');
     expect(state.nextLabel()).toBe('Finish');
     expect(state.answeredCount()).toBe(0);
   });
@@ -226,8 +253,6 @@ describe('DailyPractice', () => {
 
     (radioInputs[1] as HTMLInputElement).click();
     fixture.detectChanges();
-
-    expect(fixture.nativeElement.textContent).toContain('Immediate Feedback');
 
     const nextButton = fixture.nativeElement.querySelector(
       'button[mat-flat-button]',
@@ -252,8 +277,8 @@ describe('DailyPractice', () => {
     expect(fixture.nativeElement.textContent).toContain('Which keyword defines a function?');
   });
 
-  it('should show completion state and restart from the first question', async () => {
-    const { fixture } = setup();
+  it('should submit answers, show AI grading feedback, and restart from the first question', async () => {
+    const { fixture, mockQuizService } = setup();
     await flush();
     fixture.detectChanges();
 
@@ -265,9 +290,10 @@ describe('DailyPractice', () => {
     fixture.detectChanges();
     (
       component as unknown as {
-        onNext: () => void;
+        onNext: () => Promise<void>;
       }
     ).onNext();
+    await flush();
     fixture.detectChanges();
 
     (
@@ -276,13 +302,26 @@ describe('DailyPractice', () => {
     fixture.detectChanges();
     (
       component as unknown as {
-        onNext: () => void;
+        onNext: () => Promise<void>;
       }
     ).onNext();
+    await flush();
     fixture.detectChanges();
 
+    expect(mockQuizService.submitQuiz).toHaveBeenCalledWith(101, {
+      answers: [
+        { question_id: 1, selected_choice_id: 2 },
+        { question_id: 2, selected_choice_id: 3 },
+      ],
+    });
     expect(fixture.nativeElement.textContent).toContain('Challenge complete');
+    expect(fixture.nativeElement.textContent).toContain('Score: 50% (1/2 correct)');
     expect(fixture.nativeElement.textContent).toContain('You answered 2 out of 2 questions.');
+    expect(fixture.nativeElement.textContent).toContain('Correct');
+    expect(fixture.nativeElement.textContent).toContain('Incorrect');
+    expect(fixture.nativeElement.textContent).toContain(
+      'A dictionary stores key-value pairs in Python.',
+    );
 
     const restartButton = Array.from(fixture.nativeElement.querySelectorAll('button')).find(
       (button) => (button as HTMLButtonElement).textContent?.includes('Try Again'),
@@ -296,32 +335,31 @@ describe('DailyPractice', () => {
     expect(fixture.nativeElement.textContent).not.toContain('Challenge complete');
   });
 
-  it('should fall back to mock quiz mode when no strive activity is available', async () => {
+  it('should show an error when no course activities are available', async () => {
     const { fixture, mockQuizService } = setup({ activityList: [] });
     await flush();
     fixture.detectChanges();
 
     expect(mockQuizService.startQuiz).not.toHaveBeenCalled();
+    expect(fixture.nativeElement.textContent).toContain('Quiz unavailable');
     expect(fixture.nativeElement.textContent).toContain(
-      'Showing sample challenge questions while Strive activities are unavailable.',
-    );
-    expect(fixture.nativeElement.textContent).toContain(
-      'Which keyword is used to define a function in Python?',
+      'Unable to load challenge questions because no course activities exist.',
     );
   });
 
-  it('should fall back when the course context is missing', async () => {
+  it('should show an error when the course context is missing', async () => {
     const { fixture, mockActivityService } = setup({ routeCourseId: 'not-a-number' });
     await flush();
     fixture.detectChanges();
 
     expect(mockActivityService.list).not.toHaveBeenCalled();
+    expect(fixture.nativeElement.textContent).toContain('Quiz unavailable');
     expect(fixture.nativeElement.textContent).toContain(
-      'Showing sample challenge questions because course context is missing.',
+      'Unable to load challenge questions because course context is missing.',
     );
   });
 
-  it('should fall back when quiz generation returns no questions', async () => {
+  it('should show an error when quiz generation returns no questions', async () => {
     const emptyQuiz: QuizQuestionsResponse = {
       ...fakeQuestionsResponse,
       questions: [],
@@ -333,12 +371,11 @@ describe('DailyPractice', () => {
 
     expect(mockQuizService.startQuiz).toHaveBeenCalled();
     expect(mockQuizService.getQuiz).toHaveBeenCalled();
-    expect(fixture.nativeElement.textContent).toContain(
-      'Showing sample challenge questions while quiz questions are being generated.',
-    );
+    expect(fixture.nativeElement.textContent).toContain('Quiz unavailable');
+    expect(fixture.nativeElement.textContent).toContain('The quiz service returned no questions.');
   });
 
-  it('should fall back when the quiz API rejects', async () => {
+  it('should show an error when the quiz API rejects', async () => {
     const { fixture, mockActivityService, mockQuizService } = setup({
       loadActivities: () => Promise.reject(new Error('network error')),
     });
@@ -347,8 +384,82 @@ describe('DailyPractice', () => {
 
     expect(mockActivityService.list).toHaveBeenCalled();
     expect(mockQuizService.startQuiz).not.toHaveBeenCalled();
+    expect(fixture.nativeElement.textContent).toContain('Quiz unavailable');
     expect(fixture.nativeElement.textContent).toContain(
-      'Showing sample challenge questions while the Strive quiz API is unavailable.',
+      'Unable to load challenge questions from the Strive quiz API.',
     );
+  });
+
+  it('should show an error when quiz submission fails', async () => {
+    const { fixture, mockQuizService } = setup();
+    mockQuizService.submitQuiz.mockImplementation(() =>
+      Promise.reject(new Error('submission failed')),
+    );
+    await flush();
+    fixture.detectChanges();
+
+    const component = fixture.componentInstance as DailyPractice;
+
+    (
+      component as unknown as { selectChoice: (questionId: number, choiceId: number) => void }
+    ).selectChoice(1, 2);
+    await (
+      component as unknown as {
+        onNext: () => Promise<void>;
+      }
+    ).onNext();
+    await flush();
+    fixture.detectChanges();
+
+    (
+      component as unknown as { selectChoice: (questionId: number, choiceId: number) => void }
+    ).selectChoice(2, 3);
+    await (
+      component as unknown as {
+        onNext: () => Promise<void>;
+      }
+    ).onNext();
+    await flush();
+    fixture.detectChanges();
+
+    expect(mockQuizService.submitQuiz).toHaveBeenCalled();
+    expect(fixture.nativeElement.textContent).not.toContain('Challenge complete');
+    expect(fixture.nativeElement.textContent).toContain(
+      'Unable to submit quiz answers for grading. Please try again.',
+    );
+  });
+
+  it('should persist completed daily quiz score for dashboard averages', async () => {
+    const { fixture } = setup();
+    await flush();
+    fixture.detectChanges();
+
+    const component = fixture.componentInstance as DailyPractice;
+
+    (
+      component as unknown as { selectChoice: (questionId: number, choiceId: number) => void }
+    ).selectChoice(1, 2);
+    await (
+      component as unknown as {
+        onNext: () => Promise<void>;
+      }
+    ).onNext();
+    await flush();
+    fixture.detectChanges();
+
+    (
+      component as unknown as { selectChoice: (questionId: number, choiceId: number) => void }
+    ).selectChoice(2, 3);
+    await (
+      component as unknown as {
+        onNext: () => Promise<void>;
+      }
+    ).onNext();
+    await flush();
+    fixture.detectChanges();
+
+    const stored = localStorage.getItem(RECENT_DAILY_SCORES_STORAGE_KEY);
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored as string)).toEqual([50]);
   });
 });

--- a/frontend/src/app/courses/course-detail/student/daily-practice/daily-practice.component.ts
+++ b/frontend/src/app/courses/course-detail/student/daily-practice/daily-practice.component.ts
@@ -12,53 +12,11 @@ import { computed, signal } from '@angular/core';
 import { PageTitleService } from '../../../../page-title.service';
 import { ActivityService } from '../../activities/activity.service';
 import { Activity } from '../../../../api/models';
-import { QuizQuestionsResponse } from './strive-quiz.models';
+import { QuizQuestionsResponse, QuizSubmitResponse } from './strive-quiz.models';
 import { StriveQuizService } from './strive-quiz.service';
 
-const IMMEDIATE_FEEDBACK_PLACEHOLDER =
-  'Good effort. Detailed feedback will be available in the next iteration.';
-
-const FALLBACK_QUIZ: QuizQuestionsResponse = {
-  id: 0,
-  activity_id: 0,
-  student_pid: 0,
-  status: 'in_progress',
-  mode: 'daily',
-  module_name: null,
-  topic: 'Python Basics',
-  questions: [
-    {
-      question_id: 1,
-      text: 'Which keyword is used to define a function in Python?',
-      choices: [
-        { id: 1, text: 'function' },
-        { id: 2, text: 'def' },
-        { id: 3, text: 'lambda' },
-        { id: 4, text: 'fun' },
-      ],
-    },
-    {
-      question_id: 2,
-      text: 'Which data structure stores key-value pairs?',
-      choices: [
-        { id: 1, text: 'List' },
-        { id: 2, text: 'Tuple' },
-        { id: 3, text: 'Dictionary' },
-        { id: 4, text: 'Set' },
-      ],
-    },
-    {
-      question_id: 3,
-      text: 'What does len([1, 2, 3, 4]) return?',
-      choices: [
-        { id: 1, text: '3' },
-        { id: 2, text: '4' },
-        { id: 3, text: '5' },
-        { id: 4, text: 'Error' },
-      ],
-    },
-  ],
-};
+export const RECENT_DAILY_SCORES_STORAGE_KEY = 'lwai-recent-daily-scores';
+const MAX_RECENT_DAILY_SCORES = 10;
 
 /** Placeholder page for the daily-practice experience. */
 @Component({
@@ -74,12 +32,12 @@ export class DailyPractice {
   private readonly striveQuizService = inject(StriveQuizService);
 
   protected readonly loading = signal(true);
+  protected readonly submitting = signal(false);
   protected readonly message = signal('');
-  protected readonly usingMockData = signal(false);
   protected readonly quiz = signal<QuizQuestionsResponse | null>(null);
+  protected readonly submissionResult = signal<QuizSubmitResponse | null>(null);
   protected readonly currentQuestionIndex = signal(0);
   protected readonly selectedChoicesByQuestion = signal<Record<number, number>>({});
-  protected readonly immediateFeedbackByQuestion = signal<Record<number, string>>({});
   protected readonly complete = signal(false);
 
   protected readonly totalQuestions = computed(() => this.quiz()?.questions.length ?? 0);
@@ -100,17 +58,17 @@ export class DailyPractice {
     if (question === null) return null;
     return this.selectedChoicesByQuestion()[question.question_id] ?? null;
   });
-  protected readonly immediateFeedbackForCurrent = computed(() => {
-    const question = this.currentQuestion();
-    if (question === null) return '';
-    return this.immediateFeedbackByQuestion()[question.question_id] ?? '';
-  });
   protected readonly nextLabel = computed(() =>
     this.questionNumber() >= this.totalQuestions() ? 'Finish' : 'Next',
   );
   protected readonly answeredCount = computed(
     () => Object.keys(this.selectedChoicesByQuestion()).length,
   );
+  protected readonly scorePercent = computed(() => Math.round(this.submissionResult()?.score ?? 0));
+  protected readonly feedbackByQuestionId = computed(() => {
+    const feedback = this.submissionResult()?.feedback ?? [];
+    return new Map(feedback.map((entry) => [entry.question_id, entry]));
+  });
 
   constructor() {
     this.titleService.setTitle("Today's Challenge");
@@ -122,17 +80,13 @@ export class DailyPractice {
       ...state,
       [questionId]: choiceId,
     }));
-    this.immediateFeedbackByQuestion.update((state) => ({
-      ...state,
-      [questionId]: IMMEDIATE_FEEDBACK_PLACEHOLDER,
-    }));
   }
 
-  protected onNext(): void {
+  protected async onNext(): Promise<void> {
     if (!this.hasAnsweredCurrent()) return;
 
     if (this.questionNumber() >= this.totalQuestions()) {
-      this.complete.set(true);
+      await this.submitCurrentQuiz();
       return;
     }
 
@@ -142,7 +96,7 @@ export class DailyPractice {
   protected restart(): void {
     this.currentQuestionIndex.set(0);
     this.selectedChoicesByQuestion.set({});
-    this.immediateFeedbackByQuestion.set({});
+    this.submissionResult.set(null);
     this.complete.set(false);
   }
 
@@ -150,33 +104,27 @@ export class DailyPractice {
     const courseId = Number(this.route.parent?.parent?.snapshot.paramMap.get('id'));
 
     if (Number.isNaN(courseId)) {
-      this.loadFallbackQuiz(
-        'Showing sample challenge questions because course context is missing.',
-      );
+      this.setLoadError('Unable to load challenge questions because course context is missing.');
       return;
     }
 
     try {
       const activities = await this.activityService.list(courseId);
-      const striveActivity = this.findStriveActivity(activities);
+      const quizActivity = activities[0] ?? null;
 
-      if (striveActivity === null) {
-        this.loadFallbackQuiz(
-          'Showing sample challenge questions while Strive activities are unavailable.',
-        );
+      if (quizActivity === null) {
+        this.setLoadError('Unable to load challenge questions because no course activities exist.');
         return;
       }
 
-      const createdQuiz = await this.striveQuizService.startQuiz(striveActivity.id, {
+      const createdQuiz = await this.striveQuizService.startQuiz(quizActivity.id, {
         mode: 'daily',
         question_count: 5,
       });
       const quiz = await this.striveQuizService.getQuiz(createdQuiz.id);
 
       if (quiz.questions.length === 0) {
-        this.loadFallbackQuiz(
-          'Showing sample challenge questions while quiz questions are being generated.',
-        );
+        this.setLoadError('The quiz service returned no questions.');
         return;
       }
 
@@ -187,26 +135,64 @@ export class DailyPractice {
           choices: question.choices.slice(0, 4),
         })),
       });
+      this.submissionResult.set(null);
       this.message.set('');
-      this.usingMockData.set(false);
     } catch {
-      this.loadFallbackQuiz(
-        'Showing sample challenge questions while the Strive quiz API is unavailable.',
-      );
+      this.setLoadError('Unable to load challenge questions from the Strive quiz API.');
     } finally {
       this.loading.set(false);
     }
   }
 
-  private findStriveActivity(activities: Activity[]): Activity | null {
-    const match = activities.find((activity) => activity.type.toLowerCase().includes('strive'));
-    return match ?? null;
+  private async submitCurrentQuiz(): Promise<void> {
+    const quiz = this.quiz();
+    if (quiz === null) return;
+
+    this.submitting.set(true);
+
+    try {
+      const answers = quiz.questions.map((question) => ({
+        question_id: question.question_id,
+        selected_choice_id: this.selectedChoicesByQuestion()[question.question_id],
+      }));
+
+      const result = await this.striveQuizService.submitQuiz(quiz.id, { answers });
+      this.submissionResult.set(result);
+      this.persistRecentDailyScore(result.score);
+      this.message.set('');
+      this.complete.set(true);
+    } catch {
+      this.message.set('Unable to submit quiz answers for grading. Please try again.');
+    } finally {
+      this.submitting.set(false);
+    }
   }
 
-  private loadFallbackQuiz(message: string): void {
-    this.quiz.set(FALLBACK_QUIZ);
+  private persistRecentDailyScore(score: number): void {
+    if (typeof localStorage === 'undefined' || !Number.isFinite(score)) {
+      return;
+    }
+
+    let existingScores: number[] = [];
+    try {
+      const raw = localStorage.getItem(RECENT_DAILY_SCORES_STORAGE_KEY);
+      const parsed = raw ? (JSON.parse(raw) as unknown) : [];
+      if (Array.isArray(parsed)) {
+        existingScores = parsed.filter(
+          (value): value is number => typeof value === 'number' && Number.isFinite(value),
+        );
+      }
+    } catch {
+      existingScores = [];
+    }
+
+    const updated = [score, ...existingScores].slice(0, MAX_RECENT_DAILY_SCORES);
+    localStorage.setItem(RECENT_DAILY_SCORES_STORAGE_KEY, JSON.stringify(updated));
+  }
+
+  private setLoadError(message: string): void {
+    this.quiz.set(null);
     this.message.set(message);
-    this.usingMockData.set(true);
     this.loading.set(false);
   }
 }

--- a/frontend/src/app/courses/course-detail/student/student-view.component.html
+++ b/frontend/src/app/courses/course-detail/student/student-view.component.html
@@ -16,7 +16,7 @@
   </header>
 
   <section class="grid gap-4 md:grid-cols-3" aria-label="Performance stats overview">
-    @for (stat of topLevelStats; track stat.label) {
+    @for (stat of topLevelStats(); track stat.label) {
       <mat-card appearance="outlined">
         <mat-card-content class="space-y-1">
           <p class="text-sm font-medium opacity-75">{{ stat.label }}</p>

--- a/frontend/src/app/courses/course-detail/student/student-view.component.spec.ts
+++ b/frontend/src/app/courses/course-detail/student/student-view.component.spec.ts
@@ -8,8 +8,13 @@ import { provideRouter } from '@angular/router';
 import { StudentView } from './student-view.component';
 import { PageTitleService } from '../../../page-title.service';
 import { LayoutNavigationService } from '../../../layout/layout-navigation.service';
+import { RECENT_DAILY_SCORES_STORAGE_KEY } from './daily-practice/daily-practice.component';
 
 describe('StudentView', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it('should set the page title and show student dashboard copy', () => {
     const mockPageTitle = {
       setTitle: vi.fn(),
@@ -31,5 +36,31 @@ describe('StudentView', () => {
     expect(mockPageTitle.setTitle).toHaveBeenCalledWith('Student Dashboard');
     expect(fixture.nativeElement.textContent).toContain('Daily Challenge');
     expect(fixture.nativeElement.textContent).toContain("Try Today's Challenge!");
+    expect(fixture.nativeElement.textContent).toContain('Average');
+    expect(fixture.nativeElement.textContent).toContain('--');
+  });
+
+  it('should render average score from recent daily challenge results', () => {
+    localStorage.setItem(RECENT_DAILY_SCORES_STORAGE_KEY, JSON.stringify([90, 80, 70]));
+
+    const mockPageTitle = {
+      setTitle: vi.fn(),
+    };
+    const mockLayoutNavigation = { clearContext: vi.fn() };
+
+    TestBed.configureTestingModule({
+      imports: [StudentView],
+      providers: [
+        provideRouter([]),
+        { provide: PageTitleService, useValue: mockPageTitle },
+        { provide: LayoutNavigationService, useValue: mockLayoutNavigation },
+      ],
+    });
+
+    const fixture = TestBed.createComponent(StudentView);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('Average');
+    expect(fixture.nativeElement.textContent).toContain('80%');
   });
 });

--- a/frontend/src/app/courses/course-detail/student/student-view.component.ts
+++ b/frontend/src/app/courses/course-detail/student/student-view.component.ts
@@ -3,12 +3,13 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
+import { Component, ChangeDetectionStrategy, computed, inject } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { RouterLink, RouterOutlet } from '@angular/router';
 import { PageTitleService } from '../../../page-title.service';
 import { LayoutNavigationService } from '../../../layout/layout-navigation.service';
+import { RECENT_DAILY_SCORES_STORAGE_KEY } from './daily-practice/daily-practice.component';
 
 type StudentTopLevelStat = {
   label: string;
@@ -26,8 +27,9 @@ type StudentTopLevelStat = {
 export class StudentView {
   private titleService = inject(PageTitleService);
   private layoutNavigation = inject(LayoutNavigationService);
+  private readonly recentDailyScores = this.readRecentDailyScores();
 
-  protected readonly topLevelStats: StudentTopLevelStat[] = [
+  protected readonly topLevelStats = computed<StudentTopLevelStat[]>(() => [
     {
       label: 'Streak',
       value: '6 days',
@@ -40,13 +42,43 @@ export class StudentView {
     },
     {
       label: 'Average',
-      value: '87%',
+      value: this.averageScoreLabel(),
       description: 'Average score across recent daily challenges',
     },
-  ];
+  ]);
 
   constructor() {
     this.layoutNavigation.clearContext();
     this.titleService.setTitle('Student Dashboard');
+  }
+
+  private averageScoreLabel(): string {
+    const scores = this.recentDailyScores;
+    if (scores.length === 0) {
+      return '--';
+    }
+
+    const total = scores.reduce((sum, score) => sum + score, 0);
+    return `${Math.round(total / scores.length)}%`;
+  }
+
+  private readRecentDailyScores(): number[] {
+    if (typeof localStorage === 'undefined') {
+      return [];
+    }
+
+    try {
+      const raw = localStorage.getItem(RECENT_DAILY_SCORES_STORAGE_KEY);
+      const parsed = raw ? (JSON.parse(raw) as unknown) : [];
+      if (!Array.isArray(parsed)) {
+        return [];
+      }
+
+      return parsed.filter(
+        (value): value is number => typeof value === 'number' && Number.isFinite(value),
+      );
+    } catch {
+      return [];
+    }
   }
 }

--- a/packages/learnwithai-core/src/learnwithai/services/strive_service.py
+++ b/packages/learnwithai-core/src/learnwithai/services/strive_service.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import json
-import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from itertools import count
 from typing import Any, List
 
+from learnwithai.config import Settings, get_settings
 from learnwithai.tables.activity import Activity
 from learnwithai.tables.user import User
 from openai import OpenAI
@@ -27,6 +27,31 @@ class _QuizHandle:
     mode: str | None = None
     module_name: str | None = None
     topic: str | None = None
+
+
+_MOCK_TOPIC_DB: dict[str, tuple[str, ...]] = {
+    "Python": (
+        "functions",
+        "lists and dictionaries",
+        "control flow",
+        "exceptions",
+        "file I/O",
+    ),
+    "Java": (
+        "classes and objects",
+        "interfaces",
+        "collections framework",
+        "exception handling",
+        "streams",
+    ),
+    "C": (
+        "pointers",
+        "memory allocation",
+        "structs",
+        "file handling",
+        "header files and compilation",
+    ),
+}
 
 
 def grade_answers(questions: List[dict], answers: Any, mode: str | None = None) -> dict[str, Any]:
@@ -61,11 +86,16 @@ def grade_answers(questions: List[dict], answers: Any, mode: str | None = None) 
         if correct:
             correct_count += 1
 
+        # Pull explanation from the question itself so LLM-generated feedback is preserved
+        question_match = next((q for q in questions if q["question_id"] == qid), None)
+        explanation = question_match.get("explanation") if question_match else None
+
         feedback.append(
             {
                 "question_id": qid,
                 "correct": correct,
                 "correct_choice_id": correct_map.get(qid),
+                "explanation": explanation,
             }
         )
 
@@ -83,135 +113,189 @@ def grade_answers(questions: List[dict], answers: Any, mode: str | None = None) 
 
 
 class StriveService:
-    """Lightweight dev implementation of Strive flows (in-memory)."""
+    """Lightweight dev implementation of Strive flows (in-memory).
 
-    def __init__(self, *_args: object, **_kwargs: object) -> None:
-        return None
+    This implementation exists solely to allow frontend/API GUI testing
+    without creating DB migrations. It is intentionally simple and not
+    suitable for production.
+    """
+
+    def __init__(self, *_args: object, settings: Settings | None = None, **_kwargs: object) -> None:
+        self.settings = settings or get_settings()
+        self.client = OpenAI(
+            api_key=self.settings.openai_api_key,
+            base_url=f"{self.settings.openai_endpoint.rstrip('/')}/openai/v1/",
+        )
+
+    def _select_language(self, module_name: str | None, topic: str | None) -> str:
+        context = " ".join(part for part in [module_name, topic] if part).lower()
+        if "java" in context:
+            return "Java"
+        if "c" in context or "pointer" in context or "memory" in context or "struct" in context:
+            return "C"
+        return "Python"
+
+    def _build_llm_prompt(self, topics: tuple[str, ...]) -> str:
+        """Build the fixed quiz-generation prompt with only the topic list swapped in."""
+
+        topic_list = ", ".join(topics)
+        return (
+            "Reference the list of topics and generate 5 mcq questions with 4 answer choices each. "
+            "Have each question come from one of the listed topics (topics go here) and have all at least one question "
+            "come from each topic so all the topics are being tested.\n"
+            f"Topics: {topic_list}\n"
+            "Keep each explanation brief (one sentence).\n"
+            "Return ONLY valid JSON as an array with this schema:\n"
+            "[\n"
+            "  {\n"
+            '    "question": "string",\n'
+            '    "choices": ["string", "string", "string", "string"],\n'
+            '    "correct_choice_index": 0,\n'
+            '    "explanation": "string"\n'
+            "  }\n"
+            "]"
+        )
+
+    def _generate_questions_with_llm(self, qcount: int, topics: tuple[str, ...]) -> List[dict]:
+        """Generate quiz questions with the LLM and normalize them into app format."""
+        prompt = self._build_llm_prompt(topics=topics)
+
+        response = self.client.chat.completions.create(
+            model=self.settings.openai_model,
+            messages=[
+                {
+                    "role": "system",
+                    "content": "You are a helpful educational question generator that returns strict JSON only.",
+                },
+                {"role": "user", "content": prompt},
+            ],
+        )
+
+        content = response.choices[0].message.content or ""
+
+        try:
+            parsed = json.loads(content)
+        except json.JSONDecodeError as exc:
+            raise ValueError("Strive quiz generation returned non-JSON content.") from exc
+
+        if not isinstance(parsed, list) or len(parsed) < qcount:
+            raise ValueError("Strive quiz generation returned too few questions.")
+
+        questions: List[dict] = []
+
+        for i, item in enumerate(parsed[:qcount], start=1):
+            if not isinstance(item, dict):
+                raise ValueError("Strive quiz generation returned an invalid question payload.")
+
+            raw_choices = item.get("choices", [])
+            if not isinstance(raw_choices, list) or len(raw_choices) != 4:
+                raise ValueError("Strive quiz generation returned invalid choices.")
+
+            correct_choice_index = item.get("correct_choice_index", 0)
+            if not isinstance(correct_choice_index, int) or correct_choice_index not in range(4):
+                raise ValueError("Strive quiz generation returned an invalid correct choice index.")
+
+            choices = [{"id": idx + 1, "text": str(choice)} for idx, choice in enumerate(raw_choices)]
+
+            questions.append(
+                {
+                    "question_id": i,
+                    "text": str(item.get("question", f"Generated question {i}")),
+                    "choices": choices,
+                    "correct_choice_id": correct_choice_index + 1,
+                    "explanation": str(
+                        item.get(
+                            "explanation",
+                            (
+                                "Step 1: Identify the relevant concept. "
+                                "Step 2: Compare the options. "
+                                "Step 3: Choose the best-supported answer."
+                            ),
+                        )
+                    ),
+                }
+            )
+
+        return questions
+
+    def _find_reusable_submission(
+        self,
+        subject: User,
+        activity: Activity,
+        *,
+        qcount: int,
+        mode: str,
+        module_name: str | None,
+        topic: str | None,
+    ) -> dict[str, Any] | None:
+        """Find an existing quiz for this user/activity/options to avoid re-generating questions."""
+        candidates: list[dict[str, Any]] = []
+
+        for data in _QUIZ_STORE.values():
+            submission = data.get("submission", {})
+            if submission.get("student_pid") != subject.pid:
+                continue
+            if submission.get("activity_id") != activity.id:
+                continue
+            if submission.get("question_count") != qcount:
+                continue
+            if submission.get("mode") != mode:
+                continue
+            if submission.get("module_name") != module_name:
+                continue
+            if submission.get("topic") != topic:
+                continue
+            if submission.get("status") not in {"in_progress", "submitted"}:
+                continue
+
+            candidates.append(data)
+
+        if not candidates:
+            return None
+
+        # Reuse the most recent matching submission.
+        return max(candidates, key=lambda item: item["submission"]["started_at"])
 
     def start_quiz(self, subject: User, activity: Activity, options: Any | None = None) -> _QuizHandle:
+        """Create an in-memory quiz and return a lightweight handle.
+
+        `options` is expected to have attributes similar to the API request
+        (question_count, mode, module_name, topic).
+        """
         qcount = getattr(options, "question_count", 5) if options is not None else 5
         mode = getattr(options, "mode", "daily") if options is not None else "daily"
         module_name = getattr(options, "module_name", None) if options is not None else None
         topic = getattr(options, "topic", None) if options is not None else None
 
+        reusable = self._find_reusable_submission(
+            subject,
+            activity,
+            qcount=qcount,
+            mode=mode,
+            module_name=module_name,
+            topic=topic,
+        )
+        if reusable is not None:
+            existing = reusable["submission"]
+            return _QuizHandle(
+                id=existing["id"],
+                activity_id=existing["activity_id"],
+                student_pid=existing["student_pid"],
+                status=existing["status"],
+                started_at=existing["started_at"],
+                question_count=existing["question_count"],
+                mode=existing.get("mode"),
+                module_name=existing.get("module_name"),
+                topic=existing.get("topic"),
+            )
+
+        language = self._select_language(module_name=module_name, topic=topic)
+        topics = _MOCK_TOPIC_DB[language]
+
         submission_id = next(_NEXT_ID)
         started_at = datetime.now(timezone.utc)
 
-        questions: List[dict] = []
-
-        # ✅ Fallback for tests (no API key)
-        if not os.getenv("OPENAI_API_KEY"):
-            for i in range(1, qcount + 1):
-                choices = [
-                    {"id": 1, "text": "Option A"},
-                    {"id": 2, "text": "Option B"},
-                    {"id": 3, "text": "Option C"},
-                    {"id": 4, "text": "Option D"},
-                ]
-                questions.append(
-                    {
-                        "question_id": i,
-                        "text": f"Sample question {i}",
-                        "choices": choices,
-                        "correct_choice_id": 1,
-                        "explanation": "Because it's the sample answer.",
-                    }
-                )
-
-        # ✅ Use LLM if API key exists
-        else:
-            try:
-                client = OpenAI()
-
-                prompt = f"""You are an expert educator creating formative assessment questions.
-
-Generate exactly {qcount} multiple choice questions based on recent lecture material.
-
-QUESTION DESIGN:
-- Focus on core concepts and learning objectives covered in recent lectures
-- Create questions that test understanding, not just memorization
-- Use realistic scenarios or examples from the course content
-- Vary difficulty levels across questions (some foundational, some applied)
-
-ANSWER FORMAT:
-- Provide exactly 4 answer choices per question
-- One choice must be clearly correct
-- Incorrect choices should be plausible but incorrect (avoid obvious distractors)
-- At least one incorrect choice should represent a common misconception
-
-EXPLANATION REQUIREMENT:
-For the correct answer, provide a detailed step-by-step explanation that:
-1. Restates the correct answer choice
-2. Explains WHY this answer is correct (the core reasoning)
-3. Shows the step-by-step logic or process used to reach the answer
-4. Reinforces the key concept being tested
-5. References relevant principles or definitions from recent lectures
-
-Make explanations clear for students reviewing their answers. Use simple language while maintaining academic accuracy.
-
-Return ONLY valid JSON array (no markdown, no code blocks):
-[
-  {{
-    "question": "Question text here",
-    "choices": ["Choice A", "Choice B", "Choice C", "Choice D"],
-    "correct_choice_index": 0,
-    "explanation": "Step 1: [reasoning]. Step 2: [logic]. Step 3: [conclusion]. Therefore, [answer] is correct because [reinforcement of key concept]."
-  }}
-]
-"""
-
-                if module_name and topic:
-                    prompt += f"\nContext: Generate questions from {module_name}, specifically on {topic}."
-                elif module_name:
-                    prompt += f"\nContext: Generate questions from {module_name}."
-                elif topic:
-                    prompt += f"\nContext: Generate questions focused on {topic}."
-
-                response = client.chat.completions.create(
-                    model="gpt-4o-mini",
-                    messages=[{"role": "user", "content": prompt}],
-                )
-
-                content = response.choices[0].message.content or "[]"
-
-                try:
-                    llm_questions = json.loads(content)
-                except Exception:
-                    llm_questions = []
-
-                for i, q in enumerate(llm_questions, start=1):
-                    choices = [
-                        {"id": idx + 1, "text": choice}
-                        for idx, choice in enumerate(q["choices"])
-                    ]
-
-                    questions.append(
-                        {
-                            "question_id": i,
-                            "text": q["question"],
-                            "choices": choices,
-                            "correct_choice_id": q["correct_choice_index"] + 1,
-                            "explanation": q["explanation"],
-                        }
-                    )
-            except Exception:
-                # Graceful fallback: if LLM fails for any reason, use sample questions
-                for i in range(1, qcount + 1):
-                    choices = [
-                        {"id": 1, "text": "Option A"},
-                        {"id": 2, "text": "Option B"},
-                        {"id": 3, "text": "Option C"},
-                        {"id": 4, "text": "Option D"},
-                    ]
-                    questions.append(
-                        {
-                            "question_id": i,
-                            "text": f"Sample question {i}",
-                            "choices": choices,
-                            "correct_choice_id": 1,
-                            "explanation": "Because it's the sample answer.",
-                        }
-                    )
+        questions = self._generate_questions_with_llm(qcount=qcount, topics=topics)
 
         _QUIZ_STORE[submission_id] = {
             "submission": {
@@ -245,6 +329,7 @@ Return ONLY valid JSON array (no markdown, no code blocks):
         if data is None:
             raise KeyError("quiz not found")
 
+        # strip correct answers from the questions when returning
         questions = []
         for q in data["questions"]:
             questions.append(
@@ -255,7 +340,8 @@ Return ONLY valid JSON array (no markdown, no code blocks):
                 }
             )
 
-        return {**data["submission"], "questions": questions}
+        resp = {**data["submission"], "questions": questions}
+        return resp
 
     def submit_quiz(self, subject: User, submission_id: int, answers: Any) -> dict[str, Any]:
         data = _QUIZ_STORE.get(int(submission_id))
@@ -273,6 +359,7 @@ Return ONLY valid JSON array (no markdown, no code blocks):
         feedback = result["feedback"]
         finished_at = datetime.now(timezone.utc)
 
+        # update store
         data["submission"].update({"status": "submitted", "finished_at": finished_at})
 
         return {

--- a/packages/learnwithai-core/src/learnwithai/services/strive_service.py
+++ b/packages/learnwithai-core/src/learnwithai/services/strive_service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from itertools import count
@@ -7,6 +9,7 @@ from typing import Any, List
 
 from learnwithai.tables.activity import Activity
 from learnwithai.tables.user import User
+from openai import OpenAI
 
 # Simple in-memory store for dev/testing so the endpoints work without DB migrations.
 _NEXT_ID = count(1)
@@ -27,23 +30,12 @@ class _QuizHandle:
 
 
 class StriveService:
-    """Lightweight dev implementation of Strive flows (in-memory).
-
-    This implementation exists solely to allow frontend/API GUI testing
-    without creating DB migrations. It is intentionally simple and not
-    suitable for production.
-    """
+    """Lightweight dev implementation of Strive flows (in-memory)."""
 
     def __init__(self, *_args: object, **_kwargs: object) -> None:
-        # Accept repository injection but do not require it for the dev shim
         return None
 
     def start_quiz(self, subject: User, activity: Activity, options: Any | None = None) -> _QuizHandle:
-        """Create an in-memory quiz and return a lightweight handle.
-
-        `options` is expected to have attributes similar to the API request
-        (question_count, mode, module_name, topic).
-        """
         qcount = getattr(options, "question_count", 5) if options is not None else 5
         mode = getattr(options, "mode", "daily") if options is not None else "daily"
         module_name = getattr(options, "module_name", None) if options is not None else None
@@ -52,24 +44,121 @@ class StriveService:
         submission_id = next(_NEXT_ID)
         started_at = datetime.now(timezone.utc)
 
-        # Build simple questions with deterministic correct_choice_id
         questions: List[dict] = []
-        for i in range(1, qcount + 1):
-            choices = [
-                {"id": 1, "text": "Option A"},
-                {"id": 2, "text": "Option B"},
-                {"id": 3, "text": "Option C"},
-                {"id": 4, "text": "Option D"},
-            ]
-            questions.append(
-                {
-                    "question_id": i,
-                    "text": f"Sample question {i}",
-                    "choices": choices,
-                    "correct_choice_id": 1,
-                    "explanation": "Because it's the sample answer.",
-                }
-            )
+
+        # ✅ Fallback for tests (no API key)
+        if not os.getenv("OPENAI_API_KEY"):
+            for i in range(1, qcount + 1):
+                choices = [
+                    {"id": 1, "text": "Option A"},
+                    {"id": 2, "text": "Option B"},
+                    {"id": 3, "text": "Option C"},
+                    {"id": 4, "text": "Option D"},
+                ]
+                questions.append(
+                    {
+                        "question_id": i,
+                        "text": f"Sample question {i}",
+                        "choices": choices,
+                        "correct_choice_id": 1,
+                        "explanation": "Because it's the sample answer.",
+                    }
+                )
+
+        # ✅ Use LLM if API key exists
+        else:
+            try:
+                client = OpenAI()
+
+                prompt = f"""You are an expert educator creating formative assessment questions.
+
+Generate exactly {qcount} multiple choice questions based on recent lecture material.
+
+QUESTION DESIGN:
+- Focus on core concepts and learning objectives covered in recent lectures
+- Create questions that test understanding, not just memorization
+- Use realistic scenarios or examples from the course content
+- Vary difficulty levels across questions (some foundational, some applied)
+
+ANSWER FORMAT:
+- Provide exactly 4 answer choices per question
+- One choice must be clearly correct
+- Incorrect choices should be plausible but incorrect (avoid obvious distractors)
+- At least one incorrect choice should represent a common misconception
+
+EXPLANATION REQUIREMENT:
+For the correct answer, provide a detailed step-by-step explanation that:
+1. Restates the correct answer choice
+2. Explains WHY this answer is correct (the core reasoning)
+3. Shows the step-by-step logic or process used to reach the answer
+4. Reinforces the key concept being tested
+5. References relevant principles or definitions from recent lectures
+
+Make explanations clear for students reviewing their answers. Use simple language while maintaining academic accuracy.
+
+Return ONLY valid JSON array (no markdown, no code blocks):
+[
+  {{
+    "question": "Question text here",
+    "choices": ["Choice A", "Choice B", "Choice C", "Choice D"],
+    "correct_choice_index": 0,
+    "explanation": "Step 1: [reasoning]. Step 2: [logic]. Step 3: [conclusion]. Therefore, [answer] is correct because [reinforcement of key concept]."
+  }}
+]
+"""
+
+                if module_name and topic:
+                    prompt += f"\nContext: Generate questions from {module_name}, specifically on {topic}."
+                elif module_name:
+                    prompt += f"\nContext: Generate questions from {module_name}."
+                elif topic:
+                    prompt += f"\nContext: Generate questions focused on {topic}."
+
+                response = client.chat.completions.create(
+                    model="gpt-4o-mini",
+                    messages=[{"role": "user", "content": prompt}],
+                )
+
+                content = response.choices[0].message.content or "[]"
+
+                try:
+                    llm_questions = json.loads(content)
+                except Exception:
+                    llm_questions = []
+
+                for i, q in enumerate(llm_questions, start=1):
+                    choices = [
+                        {"id": idx + 1, "text": choice}
+                        for idx, choice in enumerate(q["choices"])
+                    ]
+
+                    questions.append(
+                        {
+                            "question_id": i,
+                            "text": q["question"],
+                            "choices": choices,
+                            "correct_choice_id": q["correct_choice_index"] + 1,
+                            "explanation": q["explanation"],
+                        }
+                    )
+            except Exception:
+                # Graceful fallback: if LLM fails for any reason, use sample questions
+                for i in range(1, qcount + 1):
+                    choices = [
+                        {"id": 1, "text": "Option A"},
+                        {"id": 2, "text": "Option B"},
+                        {"id": 3, "text": "Option C"},
+                        {"id": 4, "text": "Option D"},
+                    ]
+                    questions.append(
+                        {
+                            "question_id": i,
+                            "text": f"Sample question {i}",
+                            "choices": choices,
+                            "correct_choice_id": 1,
+                            "explanation": "Because it's the sample answer.",
+                        }
+                    )
 
         _QUIZ_STORE[submission_id] = {
             "submission": {
@@ -86,7 +175,7 @@ class StriveService:
             "questions": questions,
         }
 
-        h = _QuizHandle(
+        return _QuizHandle(
             id=submission_id,
             activity_id=activity.id,
             student_pid=subject.pid,
@@ -97,13 +186,12 @@ class StriveService:
             module_name=module_name,
             topic=topic,
         )
-        return h
 
     def get_quiz(self, subject: User, submission_id: int) -> dict[str, Any]:
         data = _QUIZ_STORE.get(int(submission_id))
         if data is None:
             raise KeyError("quiz not found")
-        # strip correct answers from the questions when returning
+
         questions = []
         for q in data["questions"]:
             questions.append(
@@ -113,8 +201,8 @@ class StriveService:
                     "choices": q["choices"],
                 }
             )
-        resp = {**data["submission"], "questions": questions}
-        return resp
+
+        return {**data["submission"], "questions": questions}
 
     def submit_quiz(self, subject: User, submission_id: int, answers: List[dict]) -> dict[str, Any]:
         data = _QUIZ_STORE.get(int(submission_id))
@@ -122,27 +210,29 @@ class StriveService:
             raise KeyError("quiz not found")
 
         questions = data["questions"]
-        # build a map of correct answers
         correct_map = {q["question_id"]: q["correct_choice_id"] for q in questions}
+        explanation_map = {q["question_id"]: q.get("explanation", "No explanation available.") for q in questions}
         feedback = []
         correct_count = 0
+
         for a in answers:
             if isinstance(a, dict):
                 qid = int(a["question_id"])
                 selected = int(a["selected_choice_id"])
             else:
-                # Pydantic model objects may be passed; read attributes
                 qid = int(getattr(a, "question_id"))
                 selected = int(getattr(a, "selected_choice_id"))
+
             correct = correct_map.get(qid) == selected
             if correct:
                 correct_count += 1
+
             feedback.append(
                 {
                     "question_id": qid,
                     "correct": correct,
                     "correct_choice_id": correct_map.get(qid),
-                    "explanation": "Because it's the sample answer.",
+                    "explanation": explanation_map.get(qid, "No explanation available."),
                 }
             )
 
@@ -150,7 +240,6 @@ class StriveService:
         score = (correct_count / total) * 100.0 if total > 0 else 0.0
         finished_at = datetime.now(timezone.utc)
 
-        # update store
         data["submission"].update({"status": "submitted", "finished_at": finished_at})
 
         return {

--- a/packages/learnwithai-core/test/services/test_strive_service.py
+++ b/packages/learnwithai-core/test/services/test_strive_service.py
@@ -61,6 +61,20 @@ def test_get_and_submit_raise_for_missing_quiz() -> None:
     except KeyError:
         pass
 
+
+def test_start_quiz_reuses_existing_matching_submission() -> None:
+    svc = StriveService()
+    subject = cast(User, type("U", (), {"pid": 456})())
+    activity = cast(Activity, type("A", (), {"id": 77})())
+
+    options = type("O", (), {"question_count": 5, "mode": "daily", "module_name": None, "topic": None})()
+
+    first = svc.start_quiz(subject=subject, activity=activity, options=options)
+    second = svc.start_quiz(subject=subject, activity=activity, options=options)
+
+    assert second.id == first.id
+    assert second.question_count == first.question_count
+
     try:
         svc.submit_quiz(subject=subject, submission_id=9999999, answers=[])
         raise AssertionError("expected KeyError")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,10 @@ skip_covered = false
 [build-system]
 requires = ["uv_build>=0.10.9,<0.11.0"]
 build-backend = "uv_build"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.4.2",
+    "pytest-cov>=6.3.0",
+    "ruff>=0.11.13",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -502,6 +502,22 @@ name = "learnwithai-workspace"
 version = "0.1.0"
 source = { virtual = "." }
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.4.2" },
+    { name = "pytest-cov", specifier = ">=6.3.0" },
+    { name = "ruff", specifier = ">=0.11.13" },
+]
+
 [[package]]
 name = "multidict"
 version = "6.7.1"


### PR DESCRIPTION
## Description
This PR replaces the old placeholder daily-practice quiz with real LLM-generated questions and connects the full quiz flow from start to submit. It also updates the student dashboard so the Average card reflects recent daily challenge performance instead of a hardcoded value.

## Major Changes
- Removed hardcoded fallback questions from the daily-practice experience.
- Wired daily-practice to use the Strive quiz API end to end:
  - start quiz
  - fetch questions
  - submit answers
  - display graded feedback
- Updated quiz UX so feedback appears after completing all questions (instead of after each question).
- Added post-quiz feedback rendering with:
  - correct/incorrect status per question
  - explanation text for missed questions
- Made the dashboard Average card dynamic by calculating from recent daily challenge scores.
- Added score persistence for recent daily challenges on successful submit.
- Improved quiz startup latency in the service by reusing a matching existing submission when possible.

## Testing
- Frontend:
  - `pnpm ng test --configuration=ci --watch=false --include src/app/courses/course-detail/student/student-view.component.spec.ts --include src/app/courses/course-detail/student/daily-practice/daily-practice.component.spec.ts`
  - Result: 15 tests passed
- Backend:
  - `uv run pytest packages/learnwithai-core/test/services/test_strive_service.py -q`
  - Result: 4 tests passed

## Future Considerations
- Pull topics from actual recent lecture/activity data instead of the current mock topics.
- Add a daily quiz policy (ex: refresh per day) if we want less quiz reuse per user/activity.
- Consider server-side persistence for quiz history and average-score stats (instead of local storage only).