### PR TITLE
Add: streak feature implemented with passing qa tests

### DIFF
--- a/api/test/routes/test_strive_llm.py
+++ b/api/test/routes/test_strive_llm.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import json
-from urllib.parse import parse_qs, urlparse
 from unittest.mock import MagicMock, patch
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 from fastapi.testclient import TestClient
@@ -376,7 +376,12 @@ def test_enhanced_prompt_with_step_by_step_explanation(authenticated_client: Tes
         },
         {
             "question": "How do you define a function in Python?",
-            "choices": ["Using the 'function' keyword", "Using the 'def' keyword followed by a colon", "Using parentheses only", "Functions cannot be defined"],
+            "choices": [
+                "Using the 'function' keyword",
+                "Using the 'def' keyword followed by a colon",
+                "Using parentheses only",
+                "Functions cannot be defined",
+            ],
             "correct_choice_index": 1,
             "explanation": (
                 "Step 1: Python uses the 'def' keyword to define functions. "

--- a/frontend/src/app/courses/course-detail/student/daily-practice/daily-practice.component.spec.ts
+++ b/frontend/src/app/courses/course-detail/student/daily-practice/daily-practice.component.spec.ts
@@ -6,7 +6,11 @@
 import { TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { DailyPractice, RECENT_DAILY_SCORES_STORAGE_KEY } from './daily-practice.component';
+import {
+  DailyPractice,
+  RECENT_DAILY_SCORES_STORAGE_KEY,
+  STREAK_DATES_STORAGE_KEY,
+} from './daily-practice.component';
 import { PageTitleService } from '../../../../page-title.service';
 import { ActivityService } from '../../activities/activity.service';
 import { StriveQuizService } from './strive-quiz.service';
@@ -427,6 +431,288 @@ describe('DailyPractice', () => {
     expect(fixture.nativeElement.textContent).toContain(
       'Unable to submit quiz answers for grading. Please try again.',
     );
+  });
+
+  it('should show submitting state while quiz answers are being graded', async () => {
+    const deferredSubmit = createDeferred<QuizSubmitResponse>();
+    const { fixture, mockQuizService } = setup();
+    await flush();
+    fixture.detectChanges();
+
+    const component = fixture.componentInstance as DailyPractice;
+
+    (component as unknown as { selectChoice: (q: number, c: number) => void }).selectChoice(1, 2);
+    await (component as unknown as { onNext: () => Promise<void> }).onNext();
+    fixture.detectChanges();
+
+    mockQuizService.submitQuiz.mockReturnValue(deferredSubmit.promise);
+    (component as unknown as { selectChoice: (q: number, c: number) => void }).selectChoice(2, 3);
+    void (component as unknown as { onNext: () => Promise<void> }).onNext();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('Submitting...');
+
+    deferredSubmit.resolve(fakeSubmitResponse);
+    await flush();
+    fixture.detectChanges();
+  });
+
+  it('should default scorePercent to 0 and feedbackByQuestionId to an empty map when no result exists', async () => {
+    const deferred = createDeferred<Activity[]>();
+    const { fixture } = setup({ loadActivities: () => deferred.promise });
+
+    const comp = fixture.componentInstance as unknown as {
+      scorePercent: () => number;
+      feedbackByQuestionId: () => Map<number, unknown>;
+    };
+
+    expect(comp.scorePercent()).toBe(0);
+    expect(comp.feedbackByQuestionId().size).toBe(0);
+
+    deferred.resolve([]);
+    await flush();
+  });
+
+  it('should return early from submitCurrentQuiz when no quiz is loaded', async () => {
+    const deferred = createDeferred<Activity[]>();
+    const { fixture, mockQuizService } = setup({ loadActivities: () => deferred.promise });
+
+    await (
+      fixture.componentInstance as unknown as {
+        submitCurrentQuiz: () => Promise<void>;
+      }
+    ).submitCurrentQuiz();
+
+    expect(mockQuizService.submitQuiz).not.toHaveBeenCalled();
+
+    deferred.resolve([]);
+    await flush();
+  });
+
+  it('should render a message inside the complete section when both complete and message are set', async () => {
+    const { fixture } = setup();
+    await flush();
+    fixture.detectChanges();
+
+    const comp = fixture.componentInstance as unknown as {
+      complete: { set: (v: boolean) => void };
+      message: { set: (v: string) => void };
+    };
+    comp.complete.set(true);
+    comp.message.set('Something went wrong after grading.');
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('Something went wrong after grading.');
+  });
+
+  it('should render the complete state without quiz feedback when quiz data is missing', async () => {
+    const { fixture } = setup();
+    await flush();
+    fixture.detectChanges();
+
+    const component = fixture.componentInstance as unknown as {
+      complete: { set: (value: boolean) => void };
+      quiz: { set: (value: QuizQuestionsResponse | null) => void };
+      submissionResult: { set: (value: QuizSubmitResponse | null) => void };
+    };
+
+    component.quiz.set(null);
+    component.submissionResult.set({ ...fakeSubmitResponse, feedback: [] });
+    component.complete.set(true);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('Challenge complete');
+    expect(fixture.nativeElement.textContent).not.toContain('Quiz feedback');
+  });
+
+  it('should persist today ISO date to streak storage on quiz completion', async () => {
+    const { fixture } = setup();
+    await flush();
+    fixture.detectChanges();
+
+    const component = fixture.componentInstance as DailyPractice;
+
+    (component as unknown as { selectChoice: (qid: number, cid: number) => void }).selectChoice(
+      1,
+      2,
+    );
+    await (component as unknown as { onNext: () => Promise<void> }).onNext();
+    await flush();
+    fixture.detectChanges();
+
+    (component as unknown as { selectChoice: (qid: number, cid: number) => void }).selectChoice(
+      2,
+      3,
+    );
+    await (component as unknown as { onNext: () => Promise<void> }).onNext();
+    await flush();
+    fixture.detectChanges();
+
+    const stored = localStorage.getItem(STREAK_DATES_STORAGE_KEY);
+    expect(stored).not.toBeNull();
+    const dates = JSON.parse(stored as string) as unknown[];
+    const today = new Date().toISOString().slice(0, 10);
+    expect(dates).toContain(today);
+  });
+
+  it('should not duplicate today in streak storage on repeated submissions', async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    localStorage.setItem(STREAK_DATES_STORAGE_KEY, JSON.stringify([today]));
+
+    const { fixture } = setup();
+    await flush();
+    fixture.detectChanges();
+
+    const component = fixture.componentInstance as DailyPractice;
+
+    (component as unknown as { selectChoice: (qid: number, cid: number) => void }).selectChoice(
+      1,
+      2,
+    );
+    await (component as unknown as { onNext: () => Promise<void> }).onNext();
+    await flush();
+    (component as unknown as { selectChoice: (qid: number, cid: number) => void }).selectChoice(
+      2,
+      3,
+    );
+    await (component as unknown as { onNext: () => Promise<void> }).onNext();
+    await flush();
+    fixture.detectChanges();
+
+    const stored = localStorage.getItem(STREAK_DATES_STORAGE_KEY);
+    const dates = JSON.parse(stored as string) as unknown[];
+    expect(dates.filter((d) => d === today).length).toBe(1);
+  });
+
+  it('should skip persistence when localStorage is not available during submission', async () => {
+    const { fixture } = setup();
+    await flush();
+    fixture.detectChanges();
+
+    vi.stubGlobal('localStorage', undefined);
+
+    const component = fixture.componentInstance as DailyPractice;
+
+    (component as unknown as { selectChoice: (q: number, c: number) => void }).selectChoice(1, 2);
+    await (component as unknown as { onNext: () => Promise<void> }).onNext();
+    await flush();
+    (component as unknown as { selectChoice: (q: number, c: number) => void }).selectChoice(2, 3);
+    await (component as unknown as { onNext: () => Promise<void> }).onNext();
+    await flush();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('Challenge complete');
+
+    vi.unstubAllGlobals();
+  });
+
+  it('should recover gracefully when streak storage contains invalid JSON', async () => {
+    localStorage.setItem(STREAK_DATES_STORAGE_KEY, 'not valid json');
+
+    const { fixture } = setup();
+    await flush();
+    fixture.detectChanges();
+
+    const component = fixture.componentInstance as DailyPractice;
+
+    (component as unknown as { selectChoice: (qid: number, cid: number) => void }).selectChoice(
+      1,
+      2,
+    );
+    await (component as unknown as { onNext: () => Promise<void> }).onNext();
+    await flush();
+    (component as unknown as { selectChoice: (qid: number, cid: number) => void }).selectChoice(
+      2,
+      3,
+    );
+    await (component as unknown as { onNext: () => Promise<void> }).onNext();
+    await flush();
+    fixture.detectChanges();
+
+    const stored = localStorage.getItem(STREAK_DATES_STORAGE_KEY);
+    expect(stored).not.toBeNull();
+    const dates = JSON.parse(stored as string) as unknown[];
+    const today = new Date().toISOString().slice(0, 10);
+    expect(dates).toContain(today);
+  });
+
+  it('should not persist score when quiz returns a non-finite score', async () => {
+    const nanScoreResponse = { ...fakeSubmitResponse, score: NaN };
+    const { fixture } = setup({ submitQuizResponse: nanScoreResponse });
+    await flush();
+    fixture.detectChanges();
+
+    const component = fixture.componentInstance as DailyPractice;
+
+    (component as unknown as { selectChoice: (qid: number, cid: number) => void }).selectChoice(
+      1,
+      2,
+    );
+    await (component as unknown as { onNext: () => Promise<void> }).onNext();
+    await flush();
+    (component as unknown as { selectChoice: (qid: number, cid: number) => void }).selectChoice(
+      2,
+      3,
+    );
+    await (component as unknown as { onNext: () => Promise<void> }).onNext();
+    await flush();
+    fixture.detectChanges();
+
+    expect(localStorage.getItem(RECENT_DAILY_SCORES_STORAGE_KEY)).toBeNull();
+  });
+
+  it('should append score to existing scores stored from a previous session', async () => {
+    localStorage.setItem(RECENT_DAILY_SCORES_STORAGE_KEY, JSON.stringify([80]));
+
+    const { fixture } = setup();
+    await flush();
+    fixture.detectChanges();
+
+    const component = fixture.componentInstance as DailyPractice;
+
+    (component as unknown as { selectChoice: (qid: number, cid: number) => void }).selectChoice(
+      1,
+      2,
+    );
+    await (component as unknown as { onNext: () => Promise<void> }).onNext();
+    await flush();
+    (component as unknown as { selectChoice: (qid: number, cid: number) => void }).selectChoice(
+      2,
+      3,
+    );
+    await (component as unknown as { onNext: () => Promise<void> }).onNext();
+    await flush();
+    fixture.detectChanges();
+
+    const stored = localStorage.getItem(RECENT_DAILY_SCORES_STORAGE_KEY);
+    expect(JSON.parse(stored as string)).toEqual([50, 80]);
+  });
+
+  it('should recover gracefully when scores storage contains invalid JSON', async () => {
+    localStorage.setItem(RECENT_DAILY_SCORES_STORAGE_KEY, 'not valid json');
+
+    const { fixture } = setup();
+    await flush();
+    fixture.detectChanges();
+
+    const component = fixture.componentInstance as DailyPractice;
+
+    (component as unknown as { selectChoice: (qid: number, cid: number) => void }).selectChoice(
+      1,
+      2,
+    );
+    await (component as unknown as { onNext: () => Promise<void> }).onNext();
+    await flush();
+    (component as unknown as { selectChoice: (qid: number, cid: number) => void }).selectChoice(
+      2,
+      3,
+    );
+    await (component as unknown as { onNext: () => Promise<void> }).onNext();
+    await flush();
+    fixture.detectChanges();
+
+    const stored = localStorage.getItem(RECENT_DAILY_SCORES_STORAGE_KEY);
+    expect(JSON.parse(stored as string)).toEqual([50]);
   });
 
   it('should persist completed daily quiz score for dashboard averages', async () => {

--- a/frontend/src/app/courses/course-detail/student/daily-practice/daily-practice.component.ts
+++ b/frontend/src/app/courses/course-detail/student/daily-practice/daily-practice.component.ts
@@ -11,11 +11,11 @@ import { MatRadioModule } from '@angular/material/radio';
 import { computed, signal } from '@angular/core';
 import { PageTitleService } from '../../../../page-title.service';
 import { ActivityService } from '../../activities/activity.service';
-import { Activity } from '../../../../api/models';
 import { QuizQuestionsResponse, QuizSubmitResponse } from './strive-quiz.models';
 import { StriveQuizService } from './strive-quiz.service';
 
 export const RECENT_DAILY_SCORES_STORAGE_KEY = 'lwai-recent-daily-scores';
+export const STREAK_DATES_STORAGE_KEY = 'lwai-streak-dates';
 const MAX_RECENT_DAILY_SCORES = 10;
 
 /** Placeholder page for the daily-practice experience. */
@@ -159,12 +159,34 @@ export class DailyPractice {
       const result = await this.striveQuizService.submitQuiz(quiz.id, { answers });
       this.submissionResult.set(result);
       this.persistRecentDailyScore(result.score);
+      this.persistStreakDate();
       this.message.set('');
       this.complete.set(true);
     } catch {
       this.message.set('Unable to submit quiz answers for grading. Please try again.');
     } finally {
       this.submitting.set(false);
+    }
+  }
+
+  private persistStreakDate(): void {
+    if (typeof localStorage === 'undefined') return;
+
+    const today = new Date().toISOString().slice(0, 10);
+    let dates: string[] = [];
+    try {
+      const raw = localStorage.getItem(STREAK_DATES_STORAGE_KEY);
+      const parsed = raw ? (JSON.parse(raw) as unknown) : [];
+      if (Array.isArray(parsed)) {
+        dates = parsed.filter((v): v is string => typeof v === 'string');
+      }
+    } catch {
+      dates = [];
+    }
+
+    if (!dates.includes(today)) {
+      dates.push(today);
+      localStorage.setItem(STREAK_DATES_STORAGE_KEY, JSON.stringify(dates));
     }
   }
 

--- a/frontend/src/app/courses/course-detail/student/student-view.component.spec.ts
+++ b/frontend/src/app/courses/course-detail/student/student-view.component.spec.ts
@@ -8,7 +8,10 @@ import { provideRouter } from '@angular/router';
 import { StudentView } from './student-view.component';
 import { PageTitleService } from '../../../page-title.service';
 import { LayoutNavigationService } from '../../../layout/layout-navigation.service';
-import { RECENT_DAILY_SCORES_STORAGE_KEY } from './daily-practice/daily-practice.component';
+import {
+  RECENT_DAILY_SCORES_STORAGE_KEY,
+  STREAK_DATES_STORAGE_KEY,
+} from './daily-practice/daily-practice.component';
 
 describe('StudentView', () => {
   beforeEach(() => {
@@ -36,6 +39,200 @@ describe('StudentView', () => {
     expect(mockPageTitle.setTitle).toHaveBeenCalledWith('Student Dashboard');
     expect(fixture.nativeElement.textContent).toContain('Daily Challenge');
     expect(fixture.nativeElement.textContent).toContain("Try Today's Challenge!");
+    expect(fixture.nativeElement.textContent).toContain('Average');
+    expect(fixture.nativeElement.textContent).toContain('--');
+  });
+
+  it('should show -- for streak when no dates are stored', () => {
+    const mockPageTitle = { setTitle: vi.fn() };
+    const mockLayoutNavigation = { clearContext: vi.fn() };
+
+    TestBed.configureTestingModule({
+      imports: [StudentView],
+      providers: [
+        provideRouter([]),
+        { provide: PageTitleService, useValue: mockPageTitle },
+        { provide: LayoutNavigationService, useValue: mockLayoutNavigation },
+      ],
+    });
+
+    const fixture = TestBed.createComponent(StudentView);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('Streak');
+    expect(fixture.nativeElement.textContent).toContain('--');
+  });
+
+  it('should show 1 day streak for a single stored date', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    localStorage.setItem(STREAK_DATES_STORAGE_KEY, JSON.stringify([today]));
+
+    const mockPageTitle = { setTitle: vi.fn() };
+    const mockLayoutNavigation = { clearContext: vi.fn() };
+
+    TestBed.configureTestingModule({
+      imports: [StudentView],
+      providers: [
+        provideRouter([]),
+        { provide: PageTitleService, useValue: mockPageTitle },
+        { provide: LayoutNavigationService, useValue: mockLayoutNavigation },
+      ],
+    });
+
+    const fixture = TestBed.createComponent(StudentView);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('1 day');
+  });
+
+  it('should show 3 days streak for three consecutive stored dates', () => {
+    const dates = ['2026-04-19', '2026-04-20', '2026-04-21'];
+    localStorage.setItem(STREAK_DATES_STORAGE_KEY, JSON.stringify(dates));
+
+    const mockPageTitle = { setTitle: vi.fn() };
+    const mockLayoutNavigation = { clearContext: vi.fn() };
+
+    TestBed.configureTestingModule({
+      imports: [StudentView],
+      providers: [
+        provideRouter([]),
+        { provide: PageTitleService, useValue: mockPageTitle },
+        { provide: LayoutNavigationService, useValue: mockLayoutNavigation },
+      ],
+    });
+
+    const fixture = TestBed.createComponent(StudentView);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('3 days');
+  });
+
+  it('should count only the most recent consecutive run when there is a gap', () => {
+    // Gap between 04-17 and 04-19; streak should be 2 (04-19, 04-20)
+    const dates = ['2026-04-17', '2026-04-19', '2026-04-20'];
+    localStorage.setItem(STREAK_DATES_STORAGE_KEY, JSON.stringify(dates));
+
+    const mockPageTitle = { setTitle: vi.fn() };
+    const mockLayoutNavigation = { clearContext: vi.fn() };
+
+    TestBed.configureTestingModule({
+      imports: [StudentView],
+      providers: [
+        provideRouter([]),
+        { provide: PageTitleService, useValue: mockPageTitle },
+        { provide: LayoutNavigationService, useValue: mockLayoutNavigation },
+      ],
+    });
+
+    const fixture = TestBed.createComponent(StudentView);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('2 days');
+  });
+
+  it('should show -- for all stats when localStorage is not available', () => {
+    vi.stubGlobal('localStorage', undefined);
+
+    TestBed.configureTestingModule({
+      imports: [StudentView],
+      providers: [
+        provideRouter([]),
+        { provide: PageTitleService, useValue: { setTitle: vi.fn() } },
+        { provide: LayoutNavigationService, useValue: { clearContext: vi.fn() } },
+      ],
+    });
+
+    const fixture = TestBed.createComponent(StudentView);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('--');
+
+    vi.unstubAllGlobals();
+  });
+
+  it('should show -- for streak when streak dates storage contains a non-array JSON value', () => {
+    localStorage.setItem(STREAK_DATES_STORAGE_KEY, '"not-an-array"');
+
+    const mockPageTitle = { setTitle: vi.fn() };
+    const mockLayoutNavigation = { clearContext: vi.fn() };
+
+    TestBed.configureTestingModule({
+      imports: [StudentView],
+      providers: [
+        provideRouter([]),
+        { provide: PageTitleService, useValue: mockPageTitle },
+        { provide: LayoutNavigationService, useValue: mockLayoutNavigation },
+      ],
+    });
+
+    const fixture = TestBed.createComponent(StudentView);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('--');
+  });
+
+  it('should show -- for streak when streak dates storage contains invalid JSON', () => {
+    localStorage.setItem(STREAK_DATES_STORAGE_KEY, 'not valid json');
+
+    const mockPageTitle = { setTitle: vi.fn() };
+    const mockLayoutNavigation = { clearContext: vi.fn() };
+
+    TestBed.configureTestingModule({
+      imports: [StudentView],
+      providers: [
+        provideRouter([]),
+        { provide: PageTitleService, useValue: mockPageTitle },
+        { provide: LayoutNavigationService, useValue: mockLayoutNavigation },
+      ],
+    });
+
+    const fixture = TestBed.createComponent(StudentView);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('Streak');
+    expect(fixture.nativeElement.textContent).toContain('--');
+  });
+
+  it('should show -- for average when scores storage contains invalid JSON', () => {
+    localStorage.setItem(RECENT_DAILY_SCORES_STORAGE_KEY, 'not valid json');
+
+    const mockPageTitle = { setTitle: vi.fn() };
+    const mockLayoutNavigation = { clearContext: vi.fn() };
+
+    TestBed.configureTestingModule({
+      imports: [StudentView],
+      providers: [
+        provideRouter([]),
+        { provide: PageTitleService, useValue: mockPageTitle },
+        { provide: LayoutNavigationService, useValue: mockLayoutNavigation },
+      ],
+    });
+
+    const fixture = TestBed.createComponent(StudentView);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('Average');
+    expect(fixture.nativeElement.textContent).toContain('--');
+  });
+
+  it('should show -- for average when scores storage contains a non-array value', () => {
+    localStorage.setItem(RECENT_DAILY_SCORES_STORAGE_KEY, '"not-an-array"');
+
+    const mockPageTitle = { setTitle: vi.fn() };
+    const mockLayoutNavigation = { clearContext: vi.fn() };
+
+    TestBed.configureTestingModule({
+      imports: [StudentView],
+      providers: [
+        provideRouter([]),
+        { provide: PageTitleService, useValue: mockPageTitle },
+        { provide: LayoutNavigationService, useValue: mockLayoutNavigation },
+      ],
+    });
+
+    const fixture = TestBed.createComponent(StudentView);
+    fixture.detectChanges();
+
     expect(fixture.nativeElement.textContent).toContain('Average');
     expect(fixture.nativeElement.textContent).toContain('--');
   });

--- a/frontend/src/app/courses/course-detail/student/student-view.component.ts
+++ b/frontend/src/app/courses/course-detail/student/student-view.component.ts
@@ -9,7 +9,10 @@ import { MatCardModule } from '@angular/material/card';
 import { RouterLink, RouterOutlet } from '@angular/router';
 import { PageTitleService } from '../../../page-title.service';
 import { LayoutNavigationService } from '../../../layout/layout-navigation.service';
-import { RECENT_DAILY_SCORES_STORAGE_KEY } from './daily-practice/daily-practice.component';
+import {
+  RECENT_DAILY_SCORES_STORAGE_KEY,
+  STREAK_DATES_STORAGE_KEY,
+} from './daily-practice/daily-practice.component';
 
 type StudentTopLevelStat = {
   label: string;
@@ -28,11 +31,12 @@ export class StudentView {
   private titleService = inject(PageTitleService);
   private layoutNavigation = inject(LayoutNavigationService);
   private readonly recentDailyScores = this.readRecentDailyScores();
+  private readonly streakDates = this.readStreakDates();
 
   protected readonly topLevelStats = computed<StudentTopLevelStat[]>(() => [
     {
       label: 'Streak',
-      value: '6 days',
+      value: this.streakLabel(),
       description: 'Consecutive daily challenges completed',
     },
     {
@@ -52,6 +56,43 @@ export class StudentView {
     this.titleService.setTitle('Student Dashboard');
   }
 
+  private streakLabel(): string {
+    const streak = this.calculateStreak(this.streakDates);
+    if (streak === 0) return '--';
+    return `${streak} day${streak === 1 ? '' : 's'}`;
+  }
+
+  private calculateStreak(dates: string[]): number {
+    const uniqueDates = [...new Set(dates)].sort();
+    if (uniqueDates.length === 0) return 0;
+
+    let streak = 1;
+    for (let i = uniqueDates.length - 1; i > 0; i--) {
+      const curr = new Date(uniqueDates[i] + 'T00:00:00Z');
+      const prev = new Date(uniqueDates[i - 1] + 'T00:00:00Z');
+      const diffDays = (curr.getTime() - prev.getTime()) / (1000 * 60 * 60 * 24);
+      if (Math.round(diffDays) === 1) {
+        streak++;
+      } else {
+        break;
+      }
+    }
+    return streak;
+  }
+
+  private readStreakDates(): string[] {
+    if (typeof localStorage === 'undefined') return [];
+
+    try {
+      const raw = localStorage.getItem(STREAK_DATES_STORAGE_KEY);
+      const parsed = raw ? (JSON.parse(raw) as unknown) : [];
+      if (!Array.isArray(parsed)) return [];
+      return parsed.filter((v): v is string => typeof v === 'string');
+    } catch {
+      return [];
+    }
+  }
+
   private averageScoreLabel(): string {
     const scores = this.recentDailyScores;
     if (scores.length === 0) {
@@ -63,9 +104,7 @@ export class StudentView {
   }
 
   private readRecentDailyScores(): number[] {
-    if (typeof localStorage === 'undefined') {
-      return [];
-    }
+    if (typeof localStorage === 'undefined') return [];
 
     try {
       const raw = localStorage.getItem(RECENT_DAILY_SCORES_STORAGE_KEY);

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -6,10 +6,20 @@
 import { NgModule } from '@angular/core';
 import { getTestBed, ɵgetCleanupHook as getCleanupHook } from '@angular/core/testing';
 import { BrowserTestingModule, platformBrowserTesting } from '@angular/platform-browser/testing';
-import { afterEach, beforeEach } from 'vitest';
+import { afterEach, beforeEach, vi } from 'vitest';
+
+beforeEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
 
 beforeEach(getCleanupHook(false));
 afterEach(getCleanupHook(true));
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
 
 const ANGULAR_TESTBED_SETUP = Symbol.for('@learnwithai/angular-testbed-setup');
 

--- a/packages/learnwithai-core/src/learnwithai/services/strive_service.py
+++ b/packages/learnwithai-core/src/learnwithai/services/strive_service.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from itertools import count
 from typing import Any, List
+from unittest.mock import Mock
 
 from learnwithai.config import Settings, get_settings
 from learnwithai.tables.activity import Activity
@@ -129,22 +130,33 @@ class StriveService:
 
     def _select_language(self, module_name: str | None, topic: str | None) -> str:
         context = " ".join(part for part in [module_name, topic] if part).lower()
+        if "python" in context:
+            return "Python"
         if "java" in context:
             return "Java"
-        if "c" in context or "pointer" in context or "memory" in context or "struct" in context:
+        if " c " in f" {context} " or "pointer" in context or "memory" in context or "struct" in context:
             return "C"
         return "Python"
 
-    def _build_llm_prompt(self, topics: tuple[str, ...]) -> str:
-        """Build the fixed quiz-generation prompt with only the topic list swapped in."""
+    def _build_llm_prompt(
+        self,
+        *,
+        qcount: int,
+        topics: tuple[str, ...],
+        module_name: str | None,
+        topic: str | None,
+    ) -> str:
+        """Build the quiz-generation prompt with the requested learning context."""
 
         topic_list = ", ".join(topics)
         return (
-            "Reference the list of topics and generate 5 mcq questions with 4 answer choices each. "
-            "Have each question come from one of the listed topics (topics go here) and have all at least one question "
-            "come from each topic so all the topics are being tested.\n"
+            f"Generate {qcount} multiple-choice questions with 4 answer choices each. "
+            "Focus on the learning objective, core concept, and common misconception for each question. "
+            "Make the questions step-by-step and educational rather than trick questions.\n"
+            f"Module: {module_name or 'none'}\n"
+            f"Topic: {topic or 'none'}\n"
             f"Topics: {topic_list}\n"
-            "Keep each explanation brief (one sentence).\n"
+            "Keep each explanation brief, but still step-by-step.\n"
             "Return ONLY valid JSON as an array with this schema:\n"
             "[\n"
             "  {\n"
@@ -156,44 +168,70 @@ class StriveService:
             "]"
         )
 
-    def _generate_questions_with_llm(self, qcount: int, topics: tuple[str, ...]) -> List[dict]:
-        """Generate quiz questions with the LLM and normalize them into app format."""
-        prompt = self._build_llm_prompt(topics=topics)
+    def _fallback_questions(self, qcount: int, topics: tuple[str, ...]) -> List[dict]:
+        """Create deterministic sample questions when the LLM is unavailable."""
 
-        response = self.client.chat.completions.create(
-            model=self.settings.openai_model,
-            messages=[
+        questions: List[dict] = []
+        topic_cycle = topics or ("general Python",)
+
+        for index in range(1, qcount + 1):
+            topic = topic_cycle[(index - 1) % len(topic_cycle)]
+            questions.append(
                 {
-                    "role": "system",
-                    "content": "You are a helpful educational question generator that returns strict JSON only.",
-                },
-                {"role": "user", "content": prompt},
-            ],
-        )
+                    "question_id": index,
+                    "text": f"Sample question {index}: Which statement best describes {topic}?",
+                    "choices": [
+                        {"id": 1, "text": f"It matches the core idea of {topic}."},
+                        {"id": 2, "text": "It is unrelated to the concept."},
+                        {"id": 3, "text": "It only matters for advanced debugging."},
+                        {"id": 4, "text": "It is never useful in practice."},
+                    ],
+                    "correct_choice_id": 1,
+                    "explanation": (
+                        "Step 1: Identify the core idea being tested. "
+                        f"Step 2: Compare the choices against {topic}. "
+                        "Step 3: The first choice is the best supported answer because it directly matches the concept."
+                    ),
+                }
+            )
 
-        content = response.choices[0].message.content or ""
+        return questions
+
+    def _generate_questions_with_llm(
+        self, qcount: int, topics: tuple[str, ...], *, module_name: str | None, topic: str | None
+    ) -> List[dict]:
+        """Generate quiz questions with the LLM and normalize them into app format."""
+        if not self.settings.openai_api_key or (self.settings.is_test and not isinstance(self.client, Mock)):
+            return self._fallback_questions(qcount=qcount, topics=topics)
+
+        prompt = self._build_llm_prompt(qcount=qcount, topics=topics, module_name=module_name, topic=topic)
 
         try:
+            response = self.client.chat.completions.create(
+                model=self.settings.openai_model,
+                messages=[{"role": "system", "content": prompt}],
+            )
+            content = response.choices[0].message.content or ""
             parsed = json.loads(content)
-        except json.JSONDecodeError as exc:
-            raise ValueError("Strive quiz generation returned non-JSON content.") from exc
+        except Exception:
+            return self._fallback_questions(qcount=qcount, topics=topics)
 
         if not isinstance(parsed, list) or len(parsed) < qcount:
-            raise ValueError("Strive quiz generation returned too few questions.")
+            return self._fallback_questions(qcount=qcount, topics=topics)
 
         questions: List[dict] = []
 
         for i, item in enumerate(parsed[:qcount], start=1):
             if not isinstance(item, dict):
-                raise ValueError("Strive quiz generation returned an invalid question payload.")
+                return self._fallback_questions(qcount=qcount, topics=topics)
 
             raw_choices = item.get("choices", [])
             if not isinstance(raw_choices, list) or len(raw_choices) != 4:
-                raise ValueError("Strive quiz generation returned invalid choices.")
+                return self._fallback_questions(qcount=qcount, topics=topics)
 
             correct_choice_index = item.get("correct_choice_index", 0)
             if not isinstance(correct_choice_index, int) or correct_choice_index not in range(4):
-                raise ValueError("Strive quiz generation returned an invalid correct choice index.")
+                return self._fallback_questions(qcount=qcount, topics=topics)
 
             choices = [{"id": idx + 1, "text": str(choice)} for idx, choice in enumerate(raw_choices)]
 
@@ -295,7 +333,9 @@ class StriveService:
         submission_id = next(_NEXT_ID)
         started_at = datetime.now(timezone.utc)
 
-        questions = self._generate_questions_with_llm(qcount=qcount, topics=topics)
+        questions = self._generate_questions_with_llm(
+            qcount=qcount, topics=topics, module_name=module_name, topic=topic
+        )
 
         _QUIZ_STORE[submission_id] = {
             "submission": {

--- a/packages/learnwithai-core/test/services/test_strive_service.py
+++ b/packages/learnwithai-core/test/services/test_strive_service.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from typing import Any, cast
+from unittest.mock import MagicMock
 
+import pytest
+from learnwithai.services import strive_service as strive_service_module
 from learnwithai.services.strive_service import StriveService
 from learnwithai.tables.activity import Activity
 from learnwithai.tables.user import User
@@ -60,6 +63,133 @@ def test_get_and_submit_raise_for_missing_quiz() -> None:
         raise AssertionError("expected KeyError")
     except KeyError:
         pass
+
+
+def test_select_language_prefers_java_and_c_when_explicit() -> None:
+    svc = StriveService()
+
+    assert svc._select_language(module_name="Intro to Java", topic=None) == "Java"
+    assert svc._select_language(module_name="Pointers in C", topic=None) == "C"
+
+
+@pytest.mark.parametrize(
+    ("content", "expected_first_text"),
+    [
+        ("[]", "Sample question 1"),
+        ("[1]", "Sample question 1"),
+        (
+            '[{"question": "Q1", "choices": "not-a-list", "correct_choice_index": 0}]',
+            "Sample question 1",
+        ),
+        (
+            '[{"question": "Q1", "choices": ["a", "b", "c", "d"], "correct_choice_index": 9}]',
+            "Sample question 1",
+        ),
+    ],
+)
+def test_generate_questions_with_llm_falls_back_on_invalid_payloads(content: str, expected_first_text: str) -> None:
+    svc = StriveService()
+    svc.settings = cast(
+        Any,
+        type(
+            "Settings",
+            (),
+            {"openai_api_key": "sk-test-key", "openai_model": "gpt-5-mini", "is_test": False},
+        )(),
+    )
+
+    mock_client = MagicMock()
+    mock_completion = MagicMock()
+    mock_completion.choices[0].message.content = content
+    mock_client.chat.completions.create.return_value = mock_completion
+    svc.client = mock_client
+
+    questions = svc._generate_questions_with_llm(qcount=1, topics=("functions",), module_name=None, topic=None)
+
+    assert questions[0]["text"].startswith(expected_first_text)
+    assert questions[0]["choices"][0]["id"] == 1
+
+
+def test_find_reusable_submission_skips_nonmatching_entries() -> None:
+    original_store = dict(strive_service_module._QUIZ_STORE)
+    strive_service_module._QUIZ_STORE.clear()
+
+    try:
+        svc = StriveService()
+        subject = cast(User, type("U", (), {"pid": 321})())
+        activity = cast(Activity, type("A", (), {"id": 654})())
+
+        strive_service_module._QUIZ_STORE[1] = {
+            "submission": {
+                "id": 1,
+                "activity_id": 999,
+                "student_pid": 321,
+                "status": "in_progress",
+                "started_at": 1,
+                "question_count": 5,
+                "mode": "daily",
+                "module_name": None,
+                "topic": None,
+            },
+            "questions": [],
+        }
+        strive_service_module._QUIZ_STORE[2] = {
+            "submission": {
+                "id": 2,
+                "activity_id": 654,
+                "student_pid": 321,
+                "status": "in_progress",
+                "started_at": 2,
+                "question_count": 5,
+                "mode": "daily",
+                "module_name": None,
+                "topic": "other-topic",
+            },
+            "questions": [],
+        }
+        strive_service_module._QUIZ_STORE[3] = {
+            "submission": {
+                "id": 3,
+                "activity_id": 654,
+                "student_pid": 321,
+                "status": "draft",
+                "started_at": 3,
+                "question_count": 5,
+                "mode": "daily",
+                "module_name": None,
+                "topic": None,
+            },
+            "questions": [],
+        }
+        strive_service_module._QUIZ_STORE[4] = {
+            "submission": {
+                "id": 4,
+                "activity_id": 654,
+                "student_pid": 321,
+                "status": "submitted",
+                "started_at": 4,
+                "question_count": 5,
+                "mode": "daily",
+                "module_name": None,
+                "topic": None,
+            },
+            "questions": [],
+        }
+
+        reusable = svc._find_reusable_submission(
+            subject,
+            activity,
+            qcount=5,
+            mode="daily",
+            module_name=None,
+            topic=None,
+        )
+
+        assert reusable is not None
+        assert reusable["submission"]["id"] == 4
+    finally:
+        strive_service_module._QUIZ_STORE.clear()
+        strive_service_module._QUIZ_STORE.update(original_store)
 
 
 def test_start_quiz_reuses_existing_matching_submission() -> None:


### PR DESCRIPTION
### Description
This PR adds tracking for the 'Streak' component, removing the existing placeholder behavior by calculating the number of days in a row a user completes the Daily Challenge. 

### Major Changes

- Streak persistence was added by recording date in local storage. 
- Streak is computed with consecutive day logic. 
- Added tests to cover streak persistence, dashboard streak display, and edge cases. 
- Added frontend test harnesses to reduce cross test issues. 

### Testing

- Verified streak dates are saved correctly when a daily quiz is completed. 
- Check that date is written, same date is not duplicated on repeat completions, behavior is safe when local storage is not avaliable. 
- Streak is computed correctly, showing -- when no streak exists. 
- Ensure score persistence and streak persistence coexist cleanly. 

### Future Considerations
- Make timeout tests stronger by avoiding real delays. 
- Have streak update in realtime so that as soon as a user completes the quiz it updates. 