### PR TITLE
add: :LLM prompt to use sources as context

### DIFF
--- a/packages/learnwithai-core/src/learnwithai/services/strive_service.py
+++ b/packages/learnwithai-core/src/learnwithai/services/strive_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -123,9 +124,46 @@ class StriveService:
             "]"
         )
 
-    def _generate_questions_with_llm(self, qcount: int) -> List[dict]:
+    def _build_source_aware_llm_prompt(self, qcount: int, source_excerpt: str) -> str:
+        """Build a concise prompt grounded in uploaded source content."""
+        return (
+            f"Generate exactly {qcount} beginner-level Python multiple-choice questions for students.\n"
+            "Base questions and answers on the SOURCE CONTENT below.\n"
+            "If needed, infer simple context but do not contradict the source.\n"
+            "Each question must have exactly 4 answer choices and one correct answer.\n"
+            "Keep explanations brief (one sentence).\n"
+            "Return ONLY valid JSON as an array with schema: "
+            '[{"question":"string","choices":["string","string","string","string"],"correct_choice_index":0,"explanation":"string"}]\n'
+            "SOURCE CONTENT:\n"
+            f"{source_excerpt}"
+        )
+
+    def _extract_text_from_pdf_bytes(self, pdf_bytes: bytes, max_chars: int = 3000) -> str:
+        """Extract a best-effort text snippet from PDF bytes without external dependencies."""
+        decoded = pdf_bytes.decode("latin-1", errors="ignore")
+        streams = re.findall(r"stream\r?\n(.*?)\r?\nendstream", decoded, flags=re.DOTALL)
+
+        chunks: list[str] = []
+        for stream in streams:
+            # Heuristic extraction of literal text fragments commonly used in PDF content streams.
+            chunks.extend(re.findall(r"\(([^()]*)\)\s*T[Jj]", stream))
+            if len(" ".join(chunks)) >= max_chars:
+                break
+
+        text = " ".join(chunk.strip() for chunk in chunks if chunk.strip())
+        text = re.sub(r"\s+", " ", text).strip()
+
+        if not text:
+            return ""
+        return text[:max_chars]
+
+    def _generate_questions_with_llm(self, qcount: int, source_excerpt: str | None = None) -> List[dict]:
         """Generate quiz questions with the LLM and normalize them into app format."""
-        prompt = self._build_llm_prompt(qcount=qcount)
+        prompt = (
+            self._build_source_aware_llm_prompt(qcount=qcount, source_excerpt=source_excerpt)
+            if source_excerpt
+            else self._build_llm_prompt(qcount=qcount)
+        )
 
         last_error: Exception | None = None
 
@@ -314,12 +352,14 @@ class StriveService:
         with open(path, "wb") as fh:
             fh.write(pdf_bytes)
 
+        source_excerpt = self._extract_text_from_pdf_bytes(pdf_bytes)
+
         # Try to generate questions using the existing LLM helper. If the
         # environment is not configured for OpenAI (no API key or network),
         # fall back to a simple deterministic placeholder set so the API
         # remains usable in dev environments.
         try:
-            questions = self._generate_questions_with_llm(qcount=question_count)
+            questions = self._generate_questions_with_llm(qcount=question_count, source_excerpt=source_excerpt)
         except Exception:
             questions = []
             for i in range(1, question_count + 1):

--- a/packages/learnwithai-core/test/services/test_strive_service.py
+++ b/packages/learnwithai-core/test/services/test_strive_service.py
@@ -191,6 +191,73 @@ def test_generate_questions_rejects_invalid_correct_choice_index() -> None:
             assert "invalid correct choice index" in str(exc)
 
 
+def test_generate_questions_uses_source_aware_prompt() -> None:
+    svc = StriveService()
+    mock_completion = MagicMock()
+    mock_completion.choices[
+        0
+    ].message.content = (
+        '[{"question": "Q", "choices": ["a", "b", "c", "d"], "correct_choice_index": 0, "explanation": "x"}]'
+    )
+
+    with patch.object(svc.client.chat.completions, "create", return_value=mock_completion) as mock_create:
+        result = svc._generate_questions_with_llm(1, source_excerpt="Functions return values.")
+
+    assert len(result) == 1
+    prompt = mock_create.call_args.kwargs["messages"][1]["content"]
+    assert "Base questions and answers on the SOURCE CONTENT below." in prompt
+    assert "Functions return values." in prompt
+
+
+def test_generate_questions_without_sources_uses_backup_prompt() -> None:
+    svc = StriveService()
+    mock_completion = MagicMock()
+    mock_completion.choices[
+        0
+    ].message.content = (
+        '[{"question": "Q", "choices": ["a", "b", "c", "d"], "correct_choice_index": 0, "explanation": "x"}]'
+    )
+
+    with patch.object(svc.client.chat.completions, "create", return_value=mock_completion) as mock_create:
+        result = svc._generate_questions_with_llm(1, source_excerpt="")
+
+    assert len(result) == 1
+    prompt = mock_create.call_args.kwargs["messages"][1]["content"]
+    assert "beginner-level Python multiple-choice questions" in prompt
+    assert "SOURCE CONTENT" not in prompt
+
+
+def test_extract_text_from_pdf_bytes_returns_empty_when_no_text_fragments() -> None:
+    svc = StriveService()
+
+    pdf_bytes = b"%PDF-1.4\n1 0 obj\n<<>>\nendobj\n"
+    extracted = svc._extract_text_from_pdf_bytes(pdf_bytes)
+
+    assert extracted == ""
+
+
+def test_extract_text_from_pdf_bytes_breaks_and_truncates_at_max_chars() -> None:
+    svc = StriveService()
+
+    # Multiple TJ fragments ensure the loop can hit the early-break branch.
+    stream_payload = "(aaaaa) TJ\n(bbbbb) TJ\n(ccccc) TJ\n(dddddd) TJ\n"
+    pdf_like = f"stream\n{stream_payload}endstream\n".encode("latin-1")
+
+    extracted = svc._extract_text_from_pdf_bytes(pdf_like, max_chars=11)
+
+    assert extracted == "aaaaa bbbbb"
+
+
+def test_extract_text_from_pdf_bytes_reads_multiple_streams_when_under_limit() -> None:
+    svc = StriveService()
+
+    pdf_like = ("stream\n(hello) TJ\nendstream\nstream\n(world) TJ\nendstream\n").encode("latin-1")
+
+    extracted = svc._extract_text_from_pdf_bytes(pdf_like, max_chars=100)
+
+    assert extracted == "hello world"
+
+
 def test_reusable_submission_filters_mismatched_metadata() -> None:
     svc = StriveService()
     subject = cast(User, type("U", (), {"pid": 456})())
@@ -334,9 +401,12 @@ def test_generate_quiz_from_pdf_success(tmp_path: Any) -> None:
     with (
         patch("learnwithai.services.strive_service.os.makedirs"),
         patch("builtins.open", MagicMock()),
-        patch.object(svc, "_generate_questions_with_llm", return_value=questions),
+        patch.object(svc, "_extract_text_from_pdf_bytes", return_value="A source excerpt."),
+        patch.object(svc, "_generate_questions_with_llm", return_value=questions) as gen_mock,
     ):
         result = svc.generate_quiz_from_pdf(subject=subject, activity=activity, pdf_bytes=pdf_bytes, question_count=3)
+
+    gen_mock.assert_called_once_with(qcount=3, source_excerpt="A source excerpt.")
 
     assert result["student_pid"] == 77
     assert result["activity_id"] == 55


### PR DESCRIPTION
### Description
This PR allows users to use the added PDF upload service, which the LLM prompt uses as context to generate quiz questions. If no sources are uploaded the prompt uses the original approach, using the placeholder topics. 

### Major Changes
- In the backend there is a new _build_source_aware_llm_prompt() method that writes a prompt using sources as context.
-The _extract_text_from_pdf_bytes() extracts text from PDFs. 
- The _generate_questions_with_llm() method is updated to use the sources based prompt when sources have been uploaded. 
- generate_quiz_from_pdf() is updated to extract text from PDF and sent to LLM. 

### Testing
Tests verify source aware prompt generation, text is extracted from PDFs, and application uses original prompt when no sources are provided. 

### Future Considerations
- Current approach uses a heuristic way of extracting text from PDFs so consider a more complex approach for identifying learning objectives better. 
- Add frontend to let users upload PDFs that persist on their account.
- Store each source user uploads so they can access original material. 