### PR TITLE
add: sources persist to database instead of local storage and show up on refresh

### DIFF
--- a/api/src/api/di.py
+++ b/api/src/api/di.py
@@ -21,6 +21,7 @@ from learnwithai.repositories.async_job_repository import AsyncJobRepository
 from learnwithai.repositories.course_repository import CourseRepository
 from learnwithai.repositories.membership_repository import MembershipRepository
 from learnwithai.repositories.strive_repository import StriveRepository
+from learnwithai.repositories.strive_source_repository import StriveSourceRepository
 from learnwithai.repositories.submission_repository import SubmissionRepository
 from learnwithai.repositories.user_repository import UserRepository
 from learnwithai.services.activity_service import ActivityService
@@ -80,7 +81,9 @@ __all__ = [
     "iyow_submission_repository_factory",
     "iyow_submission_service_factory",
     "StriveRepositoryDI",
+    "StriveSourceRepositoryDI",
     "strive_repository_factory",
+    "strive_source_repository_factory",
     "strive_service_factory",
     "StriveServiceDI",
     "joke_generation_service_factory",
@@ -342,9 +345,19 @@ def strive_repository_factory(session: SessionDI) -> StriveRepository:
 StriveRepositoryDI: TypeAlias = Annotated[StriveRepository, Depends(strive_repository_factory)]
 
 
-def strive_service_factory(strive_repo: StriveRepositoryDI) -> StriveService:
+def strive_source_repository_factory(session: SessionDI) -> StriveSourceRepository:
+    """Constructs the Strive source repository bound to the current request session."""
+    return StriveSourceRepository(session)
+
+
+StriveSourceRepositoryDI: TypeAlias = Annotated[StriveSourceRepository, Depends(strive_source_repository_factory)]
+
+
+def strive_service_factory(
+    strive_repo: StriveRepositoryDI, strive_source_repo: StriveSourceRepositoryDI
+) -> StriveService:
     """Creates the Strive service for the current request."""
-    return StriveService(strive_repo)
+    return StriveService(strive_repo, strive_source_repo)
 
 
 StriveServiceDI: TypeAlias = Annotated[StriveService, Depends(strive_service_factory)]

--- a/api/src/api/lifespan.py
+++ b/api/src/api/lifespan.py
@@ -22,6 +22,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from learnwithai.config import Settings
+from learnwithai.db import create_db_and_tables
 
 from api.realtime import JobUpdateManager, consume_job_updates
 from api.routes import ws as ws_route_module
@@ -32,10 +33,14 @@ logger = logging.getLogger(__name__)
 async def _lifespan_context(application: FastAPI) -> AsyncIterator[None]:
     """Manages startup and shutdown of background resources.
 
-    Starts the RabbitMQ consumer background task on startup and
-    cancels it on shutdown.  Skips the consumer in test environments
-    where RabbitMQ is not available.
+    Creates any missing SQLModel tables on startup, then starts the RabbitMQ
+    consumer background task. Skips the consumer in test environments where
+    RabbitMQ is not available.
     """
+    del application
+
+    create_db_and_tables()
+
     manager = JobUpdateManager()
     ws_route_module.configure(manager)
 

--- a/api/src/api/models/strive.py
+++ b/api/src/api/models/strive.py
@@ -178,3 +178,41 @@ class QuizSubmitResponse(BaseModel):
     )
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class SourceSummaryResponse(BaseModel):
+    """Summary for a persisted Strive source file."""
+
+    source_id: int = Field(..., description="Source row id.", json_schema_extra={"example": 501})
+    activity_id: int = Field(
+        ..., description="Activity id the source was uploaded for.", json_schema_extra={"example": 42}
+    )
+    filename: Optional[str] = Field(
+        default=None,
+        description="Original uploaded filename.",
+        json_schema_extra={"example": "lesson-notes.pdf"},
+    )
+    content_type: str = Field(
+        ..., description="MIME type for the stored file.", json_schema_extra={"example": "application/pdf"}
+    )
+    created_at: datetime = Field(
+        ...,
+        description="UTC timestamp when the source was stored.",
+        json_schema_extra={"example": "2026-04-20T12:00:00Z"},
+    )
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SourceQuizCreateRequest(BaseModel):
+    """Request body for generating a quiz from a stored source."""
+
+    question_count: int = Field(
+        default=5,
+        description="Number of multiple-choice questions to generate (1–10).",
+        json_schema_extra={"example": 5},
+        ge=1,
+        le=10,
+    )
+
+    model_config = ConfigDict(from_attributes=True)

--- a/api/src/api/routes/strive_router.py
+++ b/api/src/api/routes/strive_router.py
@@ -12,6 +12,8 @@ from api.models.strive import (
     QuizQuestionsResponse,
     QuizSubmitRequest,
     QuizSubmitResponse,
+    SourceQuizCreateRequest,
+    SourceSummaryResponse,
 )
 
 router = APIRouter(tags=["Strive"])
@@ -83,6 +85,22 @@ def submit_quiz(
         raise HTTPException(status_code=404, detail="Quiz submission not found")
 
 
+@router.get(
+    "/sources",
+    response_model=list[SourceSummaryResponse],
+    summary="List uploaded source files for the current student",
+)
+def list_sources(
+    subject: AuthenticatedUserDI,
+    strive_svc: StriveServiceDI,
+) -> list[SourceSummaryResponse]:
+    if strive_svc is None:
+        raise HTTPException(status_code=501, detail="StriveService not wired.")
+    return [
+        SourceSummaryResponse.model_validate(source) for source in strive_svc.list_uploaded_sources(subject=subject)
+    ]
+
+
 @router.post(
     "/activities/{activity_id}/quizzes/upload-pdf",
     status_code=HTTP_201_CREATED,
@@ -124,7 +142,12 @@ def upload_pdf_and_generate_quiz(
         # Delegate to the Strive service; service should accept PDF bytes and return
         # a submission dict compatible with QuizQuestionsResponse
         result = strive_svc.generate_quiz_from_pdf(
-            subject=subject, activity=activity, pdf_bytes=content, question_count=question_count
+            subject=subject,
+            activity=activity,
+            pdf_bytes=content,
+            question_count=question_count,
+            source_filename=file.filename,
+            source_content_type=file.content_type or "application/pdf",
         )
         return QuizQuestionsResponse.model_validate(result)
     except KeyError:
@@ -133,3 +156,35 @@ def upload_pdf_and_generate_quiz(
         raise HTTPException(status_code=400, detail=str(exc))
     except Exception as exc:
         raise HTTPException(status_code=500, detail=f"Failed to generate quiz from PDF: {exc}")
+
+
+@router.post(
+    "/sources/{source_id}/quizzes",
+    status_code=HTTP_201_CREATED,
+    response_model=QuizQuestionsResponse,
+    summary="Generate a quiz from a previously stored source",
+)
+def create_source_quiz(
+    source_id: Annotated[int, Path(...)],
+    body: Annotated[SourceQuizCreateRequest, Body(...)],
+    subject: AuthenticatedUserDI,
+    strive_svc: StriveServiceDI,
+) -> QuizQuestionsResponse:
+    if strive_svc is None:
+        raise HTTPException(status_code=501, detail="StriveService not wired.")
+
+    try:
+        result = strive_svc.generate_quiz_from_source(
+            subject=subject,
+            source_id=source_id,
+            question_count=body.question_count,
+        )
+        return QuizQuestionsResponse.model_validate(result)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Source not found")
+    except PermissionError:
+        raise HTTPException(status_code=403, detail="Not allowed to use this source")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Failed to generate quiz from source: {exc}")

--- a/api/test/routes/test_strive_router_edges.py
+++ b/api/test/routes/test_strive_router_edges.py
@@ -1,13 +1,20 @@
 from datetime import datetime, timezone
 from io import BytesIO
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 from fastapi import HTTPException, UploadFile
 from starlette.datastructures import Headers
 
 from api.models.strive import QuizCreateRequest, QuizSubmitRequest
-from api.routes.strive_router import get_quiz, start_quiz, submit_quiz, upload_pdf_and_generate_quiz
+from api.routes.strive_router import (
+    create_source_quiz,
+    get_quiz,
+    list_sources,
+    start_quiz,
+    submit_quiz,
+    upload_pdf_and_generate_quiz,
+)
 
 
 class DummyActivity:
@@ -78,6 +85,12 @@ class FailingService:
 
     def generate_quiz_from_pdf(self, *a: Any, **k: Any) -> None:
         raise KeyError("no activity")
+
+    def list_uploaded_sources(self, *a: Any, **k: Any) -> None:
+        raise RuntimeError("no sources")
+
+    def generate_quiz_from_source(self, *a: Any, **k: Any) -> None:
+        raise KeyError("no source")
 
 
 def test_start_quiz_unwired_raises_501() -> None:
@@ -158,6 +171,8 @@ def test_upload_pdf_and_generate_quiz_returns_response() -> None:
         activity=activity,
         pdf_bytes=b"%PDF-1.4 test pdf",
         question_count=7,
+        source_filename="quiz.pdf",
+        source_content_type="application/pdf",
     )
 
 
@@ -268,3 +283,114 @@ def test_upload_pdf_and_generate_quiz_translates_service_errors() -> None:
         except HTTPException as e:
             assert e.status_code == expected_status
             assert e.detail == expected_detail
+
+
+def test_list_sources_returns_response() -> None:
+    subject: Any = _stub_user(123)
+
+    class Service:
+        def list_uploaded_sources(self, *a: Any, **k: Any) -> list[dict[str, Any]]:
+            return [
+                {
+                    "source_id": 11,
+                    "activity_id": 7,
+                    "filename": "saved.pdf",
+                    "content_type": "application/pdf",
+                    "created_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
+                }
+            ]
+
+    result = list_sources(subject=subject, strive_svc=cast(Any, Service()))
+
+    assert len(result) == 1
+    assert result[0].source_id == 11
+    assert result[0].filename == "saved.pdf"
+
+
+def test_create_source_quiz_returns_response() -> None:
+    subject: Any = _stub_user(123)
+
+    class Service:
+        def generate_quiz_from_source(self, *a: Any, **k: Any) -> dict[str, Any]:
+            return _make_quiz_payload()
+
+    body: Any = type("B", (), {"question_count": 5})()
+    result = create_source_quiz(source_id=11, body=body, subject=subject, strive_svc=cast(Any, Service()))
+
+    assert result.id == 101
+    assert result.activity_id == 1
+
+
+def test_create_source_quiz_translates_errors() -> None:
+    subject: Any = _stub_user(123)
+
+    class PermissionService:
+        def generate_quiz_from_source(self, *a: Any, **k: Any) -> None:
+            raise PermissionError("nope")
+
+    class GenericService:
+        def generate_quiz_from_source(self, *a: Any, **k: Any) -> None:
+            raise RuntimeError("boom")
+
+    body: Any = type("B", (), {"question_count": 5})()
+
+    try:
+        create_source_quiz(source_id=11, body=body, subject=subject, strive_svc=cast(Any, PermissionService()))
+        raise AssertionError("expected HTTPException")
+    except HTTPException as e:
+        assert e.status_code == 403
+
+    try:
+        create_source_quiz(source_id=11, body=body, subject=subject, strive_svc=cast(Any, GenericService()))
+        raise AssertionError("expected HTTPException")
+    except HTTPException as e:
+        assert e.status_code == 500
+
+
+def test_list_sources_unwired_raises_501() -> None:
+    subject: Any = _stub_user(1)
+    try:
+        list_sources(subject=subject, strive_svc=None)  # type: ignore[arg-type]
+        raise AssertionError("expected HTTPException")
+    except HTTPException as e:
+        assert e.status_code == 501
+
+
+def test_create_source_quiz_unwired_raises_501() -> None:
+    subject: Any = _stub_user(1)
+    body: Any = type("B", (), {"question_count": 5})()
+    try:
+        create_source_quiz(source_id=1, body=body, subject=subject, strive_svc=None)  # type: ignore[arg-type]
+        raise AssertionError("expected HTTPException")
+    except HTTPException as e:
+        assert e.status_code == 501
+
+
+def test_create_source_quiz_key_error_raises_404() -> None:
+    subject: Any = _stub_user(1)
+
+    class NotFoundService:
+        def generate_quiz_from_source(self, *a: Any, **k: Any) -> None:
+            raise KeyError("source not found")
+
+    body: Any = type("B", (), {"question_count": 5})()
+    try:
+        create_source_quiz(source_id=99, body=body, subject=subject, strive_svc=cast(Any, NotFoundService()))
+        raise AssertionError("expected HTTPException")
+    except HTTPException as e:
+        assert e.status_code == 404
+
+
+def test_create_source_quiz_value_error_raises_400() -> None:
+    subject: Any = _stub_user(1)
+
+    class BadValueService:
+        def generate_quiz_from_source(self, *a: Any, **k: Any) -> None:
+            raise ValueError("bad input")
+
+    body: Any = type("B", (), {"question_count": 5})()
+    try:
+        create_source_quiz(source_id=1, body=body, subject=subject, strive_svc=cast(Any, BadValueService()))
+        raise AssertionError("expected HTTPException")
+    except HTTPException as e:
+        assert e.status_code == 400

--- a/api/test/test_main.py
+++ b/api/test/test_main.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+from unittest.mock import patch
 
 import pytest
 from fastapi import FastAPI
@@ -184,8 +185,10 @@ def test_lifespan_context_skips_consumer_in_test_environment(
         with pytest.raises(StopAsyncIteration):
             await anext(lifespan)
 
-    asyncio.run(exercise())
+    with patch.object(lifespan_module, "create_db_and_tables") as create_db_and_tables_mock:
+        asyncio.run(exercise())
 
+    create_db_and_tables_mock.assert_called_once_with()
     assert called is False
 
 
@@ -221,8 +224,10 @@ def test_lifespan_context_starts_and_cancels_consumer_in_non_test_environment(
         with pytest.raises(StopAsyncIteration):
             await anext(lifespan)
 
-    asyncio.run(exercise())
+    with patch.object(lifespan_module, "create_db_and_tables") as create_db_and_tables_mock:
+        asyncio.run(exercise())
 
+    create_db_and_tables_mock.assert_called_once_with()
     assert started.is_set()
     assert cancelled.is_set()
 

--- a/frontend/src/app/courses/course-detail/student/daily-practice/strive-quiz.service.spec.ts
+++ b/frontend/src/app/courses/course-detail/student/daily-practice/strive-quiz.service.spec.ts
@@ -132,6 +132,56 @@ describe('StriveQuizService', () => {
     await expect(promise).resolves.toMatchObject({ id: 202, mode: 'daily' });
   });
 
+  it('should list persisted sources', async () => {
+    const promise = service.listSources();
+
+    const request = httpTesting.expectOne('/api/sources');
+    expect(request.request.method).toBe('GET');
+
+    request.flush([
+      {
+        source_id: 31,
+        activity_id: 7,
+        filename: 'saved-notes.pdf',
+        content_type: 'application/pdf',
+        created_at: '2026-04-20T12:00:00Z',
+      },
+    ]);
+
+    await expect(promise).resolves.toEqual([
+      {
+        source_id: 31,
+        activity_id: 7,
+        filename: 'saved-notes.pdf',
+        content_type: 'application/pdf',
+        created_at: '2026-04-20T12:00:00Z',
+      },
+    ]);
+  });
+
+  it('should create a quiz from a persisted source', async () => {
+    const promise = service.createSourceQuiz(31, 5);
+
+    const request = httpTesting.expectOne('/api/sources/31/quizzes');
+    expect(request.request.method).toBe('POST');
+    expect(request.request.body).toEqual({ question_count: 5 });
+
+    request.flush({
+      id: 303,
+      activity_id: 7,
+      student_pid: 730611076,
+      status: 'in_progress',
+      started_at: '2026-04-20T12:00:00Z',
+      question_count: 5,
+      mode: 'daily',
+      module_name: null,
+      topic: 'Saved Source',
+      questions: [],
+    });
+
+    await expect(promise).resolves.toMatchObject({ id: 303, activity_id: 7 });
+  });
+
   it('should consume and clear the pending source quiz', () => {
     const pendingQuiz: QuizQuestionsResponse = {
       id: 303,

--- a/frontend/src/app/courses/course-detail/student/daily-practice/strive-quiz.service.ts
+++ b/frontend/src/app/courses/course-detail/student/daily-practice/strive-quiz.service.ts
@@ -14,6 +14,14 @@ import {
   QuizSubmitResponse,
 } from './strive-quiz.models';
 
+export type SourceSummary = {
+  source_id: number;
+  activity_id: number;
+  filename: string | null;
+  content_type: string;
+  created_at: string;
+};
+
 /** Wraps Strive quiz route calls used by the student daily challenge UI. */
 @Injectable({ providedIn: 'root' })
 export class StriveQuizService {
@@ -54,6 +62,20 @@ export class StriveQuizService {
         `/api/activities/${activityId}/quizzes/upload-pdf`,
         formData,
       ),
+    );
+  }
+
+  /** Loads persisted source files for the current student. */
+  listSources(): Promise<SourceSummary[]> {
+    return firstValueFrom(this.http.get<SourceSummary[]>(`/api/sources`));
+  }
+
+  /** Generates a quiz from a previously saved source. */
+  createSourceQuiz(sourceId: number, questionCount: number): Promise<QuizQuestionsResponse> {
+    return firstValueFrom(
+      this.http.post<QuizQuestionsResponse>(`/api/sources/${sourceId}/quizzes`, {
+        question_count: questionCount,
+      }),
     );
   }
 

--- a/frontend/src/app/courses/course-detail/student/student-view.component.spec.ts
+++ b/frontend/src/app/courses/course-detail/student/student-view.component.spec.ts
@@ -34,6 +34,13 @@ describe('StudentView', () => {
       activeChildPath?: string | null;
       activityList?: Array<{ id: number }>;
       activityListError?: boolean;
+      persistedSources?: Array<{
+        source_id: number;
+        activity_id: number;
+        filename: string | null;
+        content_type: string;
+        created_at: string;
+      }>;
       uploadError?: boolean;
     } = {},
   ) {
@@ -53,6 +60,7 @@ describe('StudentView', () => {
       }),
     };
     const mockStriveService = {
+      listSources: vi.fn(() => Promise.resolve(options.persistedSources ?? [])),
       uploadPdfAndGenerateQuiz: vi.fn(() => {
         if (options.uploadError) {
           return Promise.reject(new Error('failed to upload source'));
@@ -60,6 +68,18 @@ describe('StudentView', () => {
 
         return Promise.resolve({
           id: 101,
+          activity_id: 7,
+          student_pid: 730611076,
+          status: 'in_progress',
+          mode: 'daily',
+          module_name: null,
+          topic: 'Python Basics',
+          questions: [{ question_id: 1, text: 'What does def do?', choices: [] }],
+        });
+      }),
+      createSourceQuiz: vi.fn(() => {
+        return Promise.resolve({
+          id: 202,
           activity_id: 7,
           student_pid: 730611076,
           status: 'in_progress',
@@ -195,6 +215,61 @@ describe('StudentView', () => {
     });
     expect(fixture.nativeElement.textContent).toContain('lesson-notes.pdf');
     expect(fixture.nativeElement.textContent).toContain('Create Source-Based Quiz (5 Questions)');
+  });
+
+  it('should load persisted sources and create a quiz from saved context after refresh', async () => {
+    const { fixture, mockActivityService, mockStriveService, mockRouter } = configureAndRender({
+      persistedSources: [
+        {
+          source_id: 31,
+          activity_id: 7,
+          filename: 'saved-notes.pdf',
+          content_type: 'application/pdf',
+          created_at: '2026-04-20T12:00:00Z',
+        },
+      ],
+    });
+    const component = fixture.componentInstance as StudentView;
+
+    await Promise.resolve();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('saved-notes.pdf');
+
+    await (
+      component as unknown as {
+        createSourceBasedQuiz: () => Promise<void>;
+      }
+    ).createSourceBasedQuiz();
+    fixture.detectChanges();
+
+    expect(mockActivityService.list).toHaveBeenCalledWith(1);
+    expect(mockStriveService.createSourceQuiz).toHaveBeenCalledWith(31, 5);
+    expect(mockStriveService.uploadPdfAndGenerateQuiz).not.toHaveBeenCalled();
+    expect(mockStriveService.setPendingSourceQuiz).toHaveBeenCalled();
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['daily-practice'], {
+      relativeTo: expect.anything(),
+      queryParams: { mode: 'source' },
+    });
+  });
+
+  it('should fall back to a generated source name when a persisted source has no filename', async () => {
+    const { fixture } = configureAndRender({
+      persistedSources: [
+        {
+          source_id: 44,
+          activity_id: 7,
+          filename: null,
+          content_type: 'application/pdf',
+          created_at: '2026-04-20T12:00:00Z',
+        },
+      ],
+    });
+
+    await Promise.resolve();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('Source 44');
   });
 
   it('should display selected file name before adding it to sources', () => {
@@ -466,5 +541,20 @@ describe('StudentView', () => {
     }
     await deferredActivities;
     await Promise.resolve();
+  });
+
+  it('should throw when requireSelectedSourceFile is called with no file attached', () => {
+    const { fixture } = configureAndRender();
+    const component = fixture.componentInstance as StudentView;
+
+    const sourceWithNoFile = { name: 'ghost.pdf' };
+
+    expect(() => {
+      (
+        component as unknown as {
+          requireSelectedSourceFile: (source: { name: string }) => File;
+        }
+      ).requireSelectedSourceFile(sourceWithNoFile);
+    }).toThrow('Selected source file is unavailable.');
   });
 });

--- a/frontend/src/app/courses/course-detail/student/student-view.component.ts
+++ b/frontend/src/app/courses/course-detail/student/student-view.component.ts
@@ -11,7 +11,7 @@ import { PageTitleService } from '../../../page-title.service';
 import { LayoutNavigationService } from '../../../layout/layout-navigation.service';
 import { RECENT_DAILY_SCORES_STORAGE_KEY } from './daily-practice/daily-practice.component';
 import { ActivityService } from '../activities/activity.service';
-import { StriveQuizService } from './daily-practice/strive-quiz.service';
+import { SourceSummary, StriveQuizService } from './daily-practice/strive-quiz.service';
 
 type StudentTopLevelStat = {
   label: string;
@@ -21,7 +21,11 @@ type StudentTopLevelStat = {
 
 type UploadedSource = {
   name: string;
-  file: File;
+  file?: File;
+  sourceId?: number;
+  activityId?: number;
+  contentType?: string;
+  createdAt?: string;
 };
 
 /** Student-facing dashboard with a daily challenge call to action and mock performance stats. */
@@ -71,6 +75,7 @@ export class StudentView {
   constructor() {
     this.layoutNavigation.clearContext();
     this.titleService.setTitle('Student Dashboard');
+    void this.loadPersistedSources();
   }
 
   protected isQuizRouteActive(): boolean {
@@ -133,12 +138,14 @@ export class StudentView {
         return;
       }
 
-      const quiz = await this.striveQuizService.uploadPdfAndGenerateQuiz(
-        quizActivity.id,
-        source.file,
-        5,
-      );
-
+      const quiz =
+        source.sourceId !== undefined
+          ? await this.striveQuizService.createSourceQuiz(source.sourceId, 5)
+          : await this.striveQuizService.uploadPdfAndGenerateQuiz(
+              quizActivity.id,
+              this.requireSelectedSourceFile(source),
+              5,
+            );
       this.striveQuizService.setPendingSourceQuiz(quiz);
       this.sourceStatusMessage.set(`Created a 5-question source-based quiz from "${source.name}".`);
       await this.router.navigate(['daily-practice'], {
@@ -150,6 +157,36 @@ export class StudentView {
     } finally {
       this.creatingSourceQuiz.set(false);
     }
+  }
+
+  private async loadPersistedSources(): Promise<void> {
+    try {
+      const sources = await this.striveQuizService.listSources();
+      this.uploadedSources.update((existing) => [
+        ...sources.map((source) => this.toUploadedSource(source)),
+        ...existing.filter((source) => source.file !== undefined),
+      ]);
+    } catch {
+      // Keep the dashboard usable even if saved sources cannot be loaded yet.
+    }
+  }
+
+  private toUploadedSource(source: SourceSummary): UploadedSource {
+    return {
+      sourceId: source.source_id,
+      activityId: source.activity_id,
+      contentType: source.content_type,
+      createdAt: source.created_at,
+      name: source.filename ?? `Source ${source.source_id}`,
+    };
+  }
+
+  private requireSelectedSourceFile(source: UploadedSource): File {
+    if (source.file === undefined) {
+      throw new Error('Selected source file is unavailable.');
+    }
+
+    return source.file;
   }
 
   private averageScoreLabel(): string {

--- a/packages/learnwithai-core/src/learnwithai/repositories/strive_source_repository.py
+++ b/packages/learnwithai-core/src/learnwithai/repositories/strive_source_repository.py
@@ -1,0 +1,36 @@
+"""Persistence helpers for uploaded Strive source files."""
+
+from learnwithai.tables.strive import StriveSource
+from sqlmodel import select
+
+from .base_repository import BaseRepository
+
+
+class StriveSourceRepository(BaseRepository[StriveSource, int]):
+    """Provides CRUD and lookup operations for uploaded source material."""
+
+    @property
+    def model_type(self) -> type[StriveSource]:
+        """Returns the SQLModel class managed by this repository."""
+        return StriveSource
+
+    def create_source(self, source: StriveSource) -> StriveSource:
+        """Persists a newly uploaded source file."""
+        return self.create(source)
+
+    def list_by_student_and_activity(self, student_pid: int, activity_id: int) -> list[StriveSource]:
+        """Returns uploaded sources for a user/activity pair, newest first."""
+        stmt = (
+            select(StriveSource)
+            .where(StriveSource.student_pid == student_pid)
+            .where(StriveSource.activity_id == activity_id)
+            .order_by(StriveSource.created_at.desc())  # type: ignore[union-attr]
+        )
+        return list(self._session.exec(stmt).all())
+
+    def list_by_student(self, student_pid: int) -> list[StriveSource]:
+        """Returns all uploaded sources for a user, newest first."""
+        stmt = (
+            select(StriveSource).where(StriveSource.student_pid == student_pid).order_by(StriveSource.created_at.desc())  # type: ignore[union-attr]
+        )
+        return list(self._session.exec(stmt).all())

--- a/packages/learnwithai-core/src/learnwithai/services/strive_service.py
+++ b/packages/learnwithai-core/src/learnwithai/services/strive_service.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
-import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from io import BytesIO
@@ -10,7 +8,9 @@ from itertools import count
 from typing import Any, List
 
 from learnwithai.config import Settings, get_settings
+from learnwithai.repositories.strive_source_repository import StriveSourceRepository
 from learnwithai.tables.activity import Activity
+from learnwithai.tables.strive import StriveSource
 from learnwithai.tables.user import User
 from openai import OpenAI
 from PyPDF2 import PdfReader
@@ -99,7 +99,15 @@ class StriveService:
     suitable for production.
     """
 
-    def __init__(self, *_args: object, settings: Settings | None = None, **_kwargs: object) -> None:
+    def __init__(
+        self,
+        quiz_repo: object | None = None,
+        source_repo: StriveSourceRepository | None = None,
+        settings: Settings | None = None,
+        **_kwargs: object,
+    ) -> None:
+        self.quiz_repo = quiz_repo
+        self.source_repo = source_repo
         self.settings = settings or get_settings()
         self.client = OpenAI(
             api_key=self.settings.openai_api_key,
@@ -126,18 +134,89 @@ class StriveService:
         )
 
     def _build_source_aware_llm_prompt(self, qcount: int, source_excerpt: str) -> str:
-        """Build a concise prompt grounded in uploaded source content."""
+        """Build a concise prompt grounded in database-backed source content."""
         return (
             f"Generate exactly {qcount} beginner-level Python multiple-choice questions for students.\n"
-            "Base questions and answers on the SOURCE CONTENT below.\n"
-            "If needed, infer simple context but do not contradict the source.\n"
+            "Base questions and answers only on the SOURCE DOCUMENTS retrieved from the database-backed\n"
+            "Strive source store below. Do not rely on filesystem paths or attempt to fetch files yourself.\n"
+            "If multiple sources are present, combine them consistently and do not contradict the stored text.\n"
             "Each question must have exactly 4 answer choices and one correct answer.\n"
             "Keep explanations brief (one sentence).\n"
             "Return ONLY valid JSON as an array with schema: "
             '[{"question":"string","choices":["string","string","string","string"],"correct_choice_index":0,"explanation":"string"}]\n'
-            "SOURCE CONTENT:\n"
+            "DATABASE SOURCE DOCUMENTS:\n"
             f"{source_excerpt}"
         )
+
+    def _build_source_context_from_sources(self, sources: list[StriveSource]) -> str:
+        """Load persisted source uploads into promptable JSON."""
+        if self.source_repo is None:
+            raise RuntimeError("StriveSourceRepository not configured.")
+
+        database_sources: list[dict[str, Any]] = []
+
+        for source in sources:
+            study_material = self.extract_study_material_from_pdf(source.pdf_bytes)
+            database_sources.append(
+                {
+                    "source_id": source.id,
+                    "filename": source.filename,
+                    "content_type": source.content_type,
+                    "created_at": source.created_at.isoformat() if source.created_at is not None else None,
+                    "study_material": study_material,
+                }
+            )
+
+        if not database_sources:
+            raise ValueError("No persisted source context is available for this activity.")
+
+        return json.dumps(
+            {
+                "retrieved_from": "database-backed_strive_source_store",
+                "sources": database_sources,
+            },
+            sort_keys=True,
+        )
+
+    def list_uploaded_sources(self, subject: User) -> list[dict[str, Any]]:
+        """Return persisted source summaries for the current student."""
+        if self.source_repo is None:
+            raise RuntimeError("StriveSourceRepository not configured.")
+
+        sources = self.source_repo.list_by_student(subject.pid)
+        return [
+            {
+                "source_id": source.id,
+                "activity_id": source.activity_id,
+                "filename": source.filename,
+                "content_type": source.content_type,
+                "created_at": source.created_at,
+            }
+            for source in sources
+        ]
+
+    def _store_uploaded_source(
+        self,
+        subject: User,
+        activity: Activity,
+        pdf_bytes: bytes,
+        *,
+        source_filename: str | None,
+        source_content_type: str,
+    ) -> StriveSource:
+        """Persist an uploaded source and return the database row."""
+        if self.source_repo is None:
+            raise RuntimeError("StriveSourceRepository not configured.")
+
+        assert activity.id is not None, "Activity must be persisted before uploading a source"
+        source = StriveSource(
+            student_pid=subject.pid,
+            activity_id=activity.id,
+            filename=source_filename,
+            content_type=source_content_type,
+            pdf_bytes=pdf_bytes,
+        )
+        return self.source_repo.create_source(source)
 
     def extract_study_material_from_pdf(self, pdf_bytes: bytes, max_chars: int = 12000) -> dict[str, Any]:
         """Extract PDF content into a JSON-serializable study material payload.
@@ -367,26 +446,30 @@ class StriveService:
         )
 
     def generate_quiz_from_pdf(
-        self, subject: User, activity: Activity, pdf_bytes: bytes, question_count: int = 5
+        self,
+        subject: User,
+        activity: Activity,
+        pdf_bytes: bytes,
+        question_count: int = 5,
+        *,
+        source_filename: str | None = None,
+        source_content_type: str = "application/pdf",
     ) -> dict[str, Any]:
         """Save uploaded PDF and generate a quiz synchronously from it.
 
-        This is a lightweight dev implementation: it persist the uploaded
-        file to `data/uploads/strive/` with a UUID filename and then
-        generates questions using the existing LLM helper. It stores the
-        submission and questions in the in-memory `_QUIZ_STORE` so other
-        endpoints (GET/submit) continue to work.
+        The uploaded source is stored in the database so the user can revisit
+        it later, and the generated quiz still uses the in-memory store for
+        the existing quiz flow.
         """
-        # Persist upload
-        uploads_dir = os.path.join("data", "uploads", "strive")
-        os.makedirs(uploads_dir, exist_ok=True)
-        filename = f"{uuid.uuid4().hex}.pdf"
-        path = os.path.join(uploads_dir, filename)
-        with open(path, "wb") as fh:
-            fh.write(pdf_bytes)
+        source = self._store_uploaded_source(
+            subject,
+            activity,
+            pdf_bytes,
+            source_filename=source_filename,
+            source_content_type=source_content_type,
+        )
 
-        study_material = self.extract_study_material_from_pdf(pdf_bytes)
-        source_excerpt = json.dumps(study_material, sort_keys=True)
+        source_excerpt = self._build_source_context_from_sources([source])
 
         # Try to generate questions using the existing LLM helper. If the
         # environment is not configured for OpenAI (no API key or network),
@@ -426,12 +509,71 @@ class StriveService:
                 "mode": "module",
                 "module_name": None,
                 "topic": None,
-                "source_path": path,
+                "source_id": source.id,
             },
             "questions": questions,
         }
 
         # Return the public-facing quiz shape (strip correct answers)
+        public_questions = [
+            {"question_id": q["question_id"], "text": q["text"], "choices": q["choices"]} for q in questions
+        ]
+
+        return {**_QUIZ_STORE[submission_id]["submission"], "questions": public_questions}
+
+    def generate_quiz_from_source(self, subject: User, source_id: int, question_count: int = 5) -> dict[str, Any]:
+        """Generate a quiz from a previously stored source."""
+        if self.source_repo is None:
+            raise RuntimeError("StriveSourceRepository not configured.")
+
+        source = self.source_repo.get_by_id(source_id)
+        if source is None:
+            raise KeyError("source not found")
+
+        if source.student_pid != subject.pid:
+            raise PermissionError("not allowed")
+
+        source_excerpt = self._build_source_context_from_sources([source])
+
+        try:
+            questions = self._generate_questions_with_llm(qcount=question_count, source_excerpt=source_excerpt)
+        except Exception:
+            questions = []
+            for i in range(1, question_count + 1):
+                questions.append(
+                    {
+                        "question_id": i,
+                        "text": f"Sample question {i} (saved source)",
+                        "choices": [
+                            {"id": 1, "text": "Choice A"},
+                            {"id": 2, "text": "Choice B"},
+                            {"id": 3, "text": "Choice C"},
+                            {"id": 4, "text": "Choice D"},
+                        ],
+                        "correct_choice_id": 1,
+                        "explanation": "Placeholder explanation.",
+                    }
+                )
+
+        submission_id = next(_NEXT_ID)
+        started_at = datetime.now(timezone.utc)
+
+        _QUIZ_STORE[submission_id] = {
+            "submission": {
+                "id": submission_id,
+                "activity_id": source.activity_id,
+                "student_pid": subject.pid,
+                "status": "in_progress",
+                "started_at": started_at,
+                "question_count": question_count,
+                "mode": "module",
+                "module_name": None,
+                "topic": None,
+                "source_id": source.id,
+            },
+            "questions": questions,
+        }
+
         public_questions = [
             {"question_id": q["question_id"], "text": q["text"], "choices": q["choices"]} for q in questions
         ]

--- a/packages/learnwithai-core/src/learnwithai/tables/__init__.py
+++ b/packages/learnwithai-core/src/learnwithai/tables/__init__.py
@@ -7,6 +7,7 @@ from .activity import Activity, ActivityType
 from .async_job import AsyncJob, AsyncJobStatus
 from .course import Course
 from .membership import Membership
+from .strive import StriveActivity, StriveQuestionSet, StriveSource, StriveSubmission
 from .submission import Submission
 from .user import User
 
@@ -17,6 +18,10 @@ __all__ = [
     "AsyncJobStatus",
     "Course",
     "Membership",
+    "StriveActivity",
+    "StriveQuestionSet",
+    "StriveSource",
+    "StriveSubmission",
     "Submission",
     "User",
 ]

--- a/packages/learnwithai-core/src/learnwithai/tables/strive.py
+++ b/packages/learnwithai-core/src/learnwithai/tables/strive.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Any, ClassVar
 
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, func
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, LargeBinary, String, func
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import Field, SQLModel
 
@@ -86,6 +86,30 @@ class StriveSubmission(SQLModel, table=True):
     status: str = Field(default="pending", sa_column=Column(String, nullable=False))
     started_at: datetime | None = Field(default=None, sa_column=Column(DateTime(timezone=True), nullable=True))
     completed_at: datetime | None = Field(default=None, sa_column=Column(DateTime(timezone=True), nullable=True))
+    created_at: datetime = Field(
+        sa_column=Column(DateTime(timezone=True), server_default=func.now(), nullable=False),
+        default=None,
+    )
+
+
+class StriveSource(SQLModel, table=True):
+    """Persisted source material uploaded for a Strive quiz."""
+
+    __tablename__: ClassVar[str] = "strive_source"  # type: ignore[override]
+
+    id: int | None = Field(
+        default=None,
+        sa_column=Column(Integer, primary_key=True, autoincrement=True),
+    )
+    student_pid: int = Field(
+        sa_column=Column(Integer, ForeignKey("user.pid"), nullable=False, index=True),
+    )
+    activity_id: int = Field(
+        sa_column=Column(Integer, ForeignKey("activity.id"), nullable=False, index=True),
+    )
+    filename: str | None = Field(default=None, sa_column=Column(String, nullable=True))
+    content_type: str = Field(sa_column=Column(String, nullable=False))
+    pdf_bytes: bytes = Field(sa_column=Column(LargeBinary, nullable=False))
     created_at: datetime = Field(
         sa_column=Column(DateTime(timezone=True), server_default=func.now(), nullable=False),
         default=None,

--- a/packages/learnwithai-core/test/repositories/test_strive_source_repository.py
+++ b/packages/learnwithai-core/test/repositories/test_strive_source_repository.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+from learnwithai.repositories.strive_source_repository import StriveSourceRepository
+from learnwithai.tables.strive import StriveSource
+
+
+class _ExecResult:
+    def __init__(self, rows: list[Any]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[Any]:
+        return self._rows
+
+
+class DummySession:
+    def __init__(self) -> None:
+        self.added: list[object] = []
+        self.flushed = False
+        self.refreshed: list[object] = []
+        self._exec_result: list[Any] = []
+
+    def add(self, obj: object) -> None:
+        self.added.append(obj)
+
+    def flush(self) -> None:
+        self.flushed = True
+
+    def refresh(self, model: object) -> None:
+        self.refreshed.append(model)
+
+    def get(self, model_type: type, model_id: int) -> None:
+        return None
+
+    def exec(self, stmt: Any) -> _ExecResult:
+        return _ExecResult(self._exec_result)
+
+
+def test_model_type() -> None:
+    repo = StriveSourceRepository(cast(Any, DummySession()))
+    assert repo.model_type is StriveSource
+
+
+def test_create_source() -> None:
+    ds = DummySession()
+    repo = StriveSourceRepository(cast(Any, ds))
+    source = cast(StriveSource, object())
+    result = repo.create_source(source)
+    assert source in ds.added
+    assert ds.flushed
+    assert source in ds.refreshed
+    assert result is source
+
+
+def test_list_by_student_and_activity() -> None:
+    ds = DummySession()
+    fake = object()
+    ds._exec_result = [fake]
+    repo = StriveSourceRepository(cast(Any, ds))
+    result = repo.list_by_student_and_activity(student_pid=1, activity_id=2)
+    assert result == [fake]
+
+
+def test_list_by_student() -> None:
+    ds = DummySession()
+    fake = object()
+    ds._exec_result = [fake]
+    repo = StriveSourceRepository(cast(Any, ds))
+    result = repo.list_by_student(student_pid=1)
+    assert result == [fake]

--- a/packages/learnwithai-core/test/services/test_strive_service.py
+++ b/packages/learnwithai-core/test/services/test_strive_service.py
@@ -206,7 +206,8 @@ def test_generate_questions_uses_source_aware_prompt() -> None:
 
     assert len(result) == 1
     prompt = mock_create.call_args.kwargs["messages"][1]["content"]
-    assert "Base questions and answers on the SOURCE CONTENT below." in prompt
+    assert "database-backed" in prompt
+    assert "SOURCE DOCUMENTS retrieved from the database-backed" in prompt
     assert "Functions return values." in prompt
 
 
@@ -225,7 +226,7 @@ def test_generate_questions_without_sources_uses_backup_prompt() -> None:
     assert len(result) == 1
     prompt = mock_create.call_args.kwargs["messages"][1]["content"]
     assert "beginner-level Python multiple-choice questions" in prompt
-    assert "SOURCE CONTENT" not in prompt
+    assert "DATABASE SOURCE DOCUMENTS" not in prompt
 
 
 def test_extract_study_material_from_pdf_returns_json_payload() -> None:
@@ -428,6 +429,21 @@ def test_reusable_submission_filters_mismatched_metadata() -> None:
 
 def test_generate_quiz_from_pdf_success(tmp_path: Any) -> None:
     svc = StriveService()
+    source_repo = MagicMock()
+    persisted_source: Any = type(
+        "Source",
+        (),
+        {
+            "id": 321,
+            "filename": "lesson-notes.pdf",
+            "content_type": "application/pdf",
+            "created_at": datetime(2026, 4, 20, tzinfo=timezone.utc),
+            "pdf_bytes": b"%PDF-1.4 test",
+        },
+    )()
+    source_repo.create_source.return_value = persisted_source
+    source_repo.list_by_student_and_activity.return_value = [persisted_source]
+    svc.source_repo = source_repo
     subject = cast(User, type("U", (), {"pid": 77})())
     activity = cast(Activity, type("A", (), {"id": 55})())
     pdf_bytes = b"%PDF-1.4 test"
@@ -436,49 +452,140 @@ def test_generate_quiz_from_pdf_success(tmp_path: Any) -> None:
     study_material = {"schema_version": 1, "source_type": "pdf", "text": "A source excerpt."}
 
     with (
-        patch("learnwithai.services.strive_service.os.makedirs"),
-        patch("builtins.open", MagicMock()),
         patch.object(svc, "extract_study_material_from_pdf", return_value=study_material) as extract_mock,
         patch.object(svc, "_generate_questions_with_llm", return_value=questions) as gen_mock,
     ):
         result = svc.generate_quiz_from_pdf(subject=subject, activity=activity, pdf_bytes=pdf_bytes, question_count=3)
 
-    extract_mock.assert_called_once_with(pdf_bytes)
+    extract_mock.assert_called_once_with(persisted_source.pdf_bytes)
     gen_mock.assert_called_once()
     assert gen_mock.call_args.kwargs["qcount"] == 3
-    assert json.loads(gen_mock.call_args.kwargs["source_excerpt"]) == study_material
+    source_excerpt = json.loads(gen_mock.call_args.kwargs["source_excerpt"])
+    assert source_excerpt["retrieved_from"] == "database-backed_strive_source_store"
+    assert len(source_excerpt["sources"]) == 1
+    assert source_excerpt["sources"][0]["source_id"] == 321
+    assert source_excerpt["sources"][0]["filename"] == "lesson-notes.pdf"
+    assert source_excerpt["sources"][0]["study_material"] == study_material
 
     assert result["student_pid"] == 77
     assert result["activity_id"] == 55
     assert result["status"] == "in_progress"
     assert result["question_count"] == 3
     assert result["mode"] == "module"
+    assert result["source_id"] == 321
     assert len(result["questions"]) == 3
     # public questions must not include correct_choice_id
     for q in result["questions"]:
         assert "correct_choice_id" not in q
     assert result["id"] in strive_service_module._QUIZ_STORE
+    source_repo.create_source.assert_called_once()
+    created_source = source_repo.create_source.call_args.args[0]
+    assert created_source.student_pid == 77
+    assert created_source.activity_id == 55
+    assert created_source.pdf_bytes == pdf_bytes
 
 
 def test_generate_quiz_from_pdf_llm_fallback(tmp_path: Any) -> None:
     svc = StriveService()
+    source_repo = MagicMock()
+    persisted_source = type(
+        "Source",
+        (),
+        {
+            "id": 654,
+            "filename": "fallback.pdf",
+            "content_type": "application/pdf",
+            "created_at": datetime(2026, 4, 20, tzinfo=timezone.utc),
+            "pdf_bytes": b"%PDF-1.4 test",
+        },
+    )()
+    source_repo.create_source.return_value = persisted_source
+    source_repo.list_by_student_and_activity.return_value = [persisted_source]
+    svc.source_repo = source_repo
     subject = cast(User, type("U", (), {"pid": 88})())
     activity = cast(Activity, type("A", (), {"id": 66})())
     pdf_bytes = b"%PDF-1.4 test"
 
     with (
-        patch("learnwithai.services.strive_service.os.makedirs"),
-        patch("builtins.open", MagicMock()),
         patch.object(svc, "extract_study_material_from_pdf", return_value={"text": "A"}),
         patch.object(svc, "_generate_questions_with_llm", side_effect=RuntimeError("LLM down")),
     ):
         result = svc.generate_quiz_from_pdf(subject=subject, activity=activity, pdf_bytes=pdf_bytes, question_count=2)
 
     assert result["question_count"] == 2
+    assert result["source_id"] == 654
     assert len(result["questions"]) == 2
     for q in result["questions"]:
         assert "PDF source" in q["text"]
         assert len(q["choices"]) == 4
+
+
+def test_list_uploaded_sources_returns_saved_sources() -> None:
+    svc = StriveService()
+    source_repo = MagicMock()
+    saved_source: Any = type(
+        "Source",
+        (),
+        {
+            "id": 901,
+            "activity_id": 44,
+            "filename": "notes.pdf",
+            "content_type": "application/pdf",
+            "created_at": datetime(2026, 4, 20, tzinfo=timezone.utc),
+        },
+    )()
+    source_repo.list_by_student.return_value = [saved_source]
+    svc.source_repo = source_repo
+    subject = cast(User, type("U", (), {"pid": 123})())
+
+    sources = svc.list_uploaded_sources(subject)
+
+    assert sources == [
+        {
+            "source_id": 901,
+            "activity_id": 44,
+            "filename": "notes.pdf",
+            "content_type": "application/pdf",
+            "created_at": saved_source.created_at,
+        }
+    ]
+    source_repo.list_by_student.assert_called_once_with(123)
+
+
+def test_generate_quiz_from_source_uses_saved_source_row() -> None:
+    svc = StriveService()
+    source_repo = MagicMock()
+    saved_source: Any = type(
+        "Source",
+        (),
+        {
+            "id": 777,
+            "activity_id": 88,
+            "student_pid": 456,
+            "filename": "saved.pdf",
+            "content_type": "application/pdf",
+            "created_at": datetime(2026, 4, 20, tzinfo=timezone.utc),
+            "pdf_bytes": b"%PDF-1.4 test",
+        },
+    )()
+    source_repo.get_by_id.return_value = saved_source
+    svc.source_repo = source_repo
+    subject = cast(User, type("U", (), {"pid": 456})())
+
+    with (
+        patch.object(svc, "extract_study_material_from_pdf", return_value={"text": "A saved source"}) as extract_mock,
+        patch.object(svc, "_generate_questions_with_llm", return_value=_mock_questions(2)) as gen_mock,
+    ):
+        result = svc.generate_quiz_from_source(subject=subject, source_id=777, question_count=2)
+
+    extract_mock.assert_called_once_with(saved_source.pdf_bytes)
+    gen_mock.assert_called_once()
+    assert gen_mock.call_args.kwargs["qcount"] == 2
+    assert "database-backed_strive_source_store" in gen_mock.call_args.kwargs["source_excerpt"]
+    assert result["source_id"] == 777
+    assert result["activity_id"] == 88
+    assert result["student_pid"] == 456
+    source_repo.get_by_id.assert_called_once_with(777)
 
 
 def test_get_and_submit_reject_other_student() -> None:
@@ -505,3 +612,93 @@ def test_get_and_submit_reject_other_student() -> None:
         raise AssertionError("expected PermissionError")
     except PermissionError:
         pass
+
+
+def test_list_uploaded_sources_no_repo() -> None:
+    svc = StriveService()
+    subject = cast(User, type("U", (), {"pid": 1})())
+    with pytest.raises(RuntimeError):
+        svc.list_uploaded_sources(subject)
+
+
+def test_store_uploaded_source_no_repo() -> None:
+    svc = StriveService()
+    subject = cast(User, type("U", (), {"pid": 1})())
+    activity = cast(Activity, type("A", (), {"id": 1})())
+    with pytest.raises(RuntimeError):
+        svc._store_uploaded_source(
+            subject, activity, b"pdf", source_filename="f.pdf", source_content_type="application/pdf"
+        )
+
+
+def test_build_source_context_no_repo() -> None:
+    svc = StriveService()
+    with pytest.raises(RuntimeError):
+        svc._build_source_context_from_sources([])
+
+
+def test_build_source_context_empty_sources() -> None:
+    svc = StriveService()
+    svc.source_repo = MagicMock()  # type: ignore[assignment]
+    with pytest.raises(ValueError, match="No persisted source context"):
+        svc._build_source_context_from_sources([])
+
+
+def test_generate_quiz_from_source_no_repo() -> None:
+    svc = StriveService()
+    subject = cast(User, type("U", (), {"pid": 1})())
+    with pytest.raises(RuntimeError):
+        svc.generate_quiz_from_source(subject=subject, source_id=1)
+
+
+def test_generate_quiz_from_source_not_found() -> None:
+    svc = StriveService()
+    source_repo = MagicMock()
+    source_repo.get_by_id.return_value = None
+    svc.source_repo = source_repo  # type: ignore[assignment]
+    subject = cast(User, type("U", (), {"pid": 1})())
+    with pytest.raises(KeyError):
+        svc.generate_quiz_from_source(subject=subject, source_id=99)
+
+
+def test_generate_quiz_from_source_permission_denied() -> None:
+    svc = StriveService()
+    source_repo = MagicMock()
+    saved_source: Any = type("Source", (), {"id": 1, "student_pid": 999, "activity_id": 1})()
+    source_repo.get_by_id.return_value = saved_source
+    svc.source_repo = source_repo  # type: ignore[assignment]
+    subject = cast(User, type("U", (), {"pid": 1})())
+    with pytest.raises(PermissionError):
+        svc.generate_quiz_from_source(subject=subject, source_id=1)
+
+
+def test_generate_quiz_from_source_llm_fallback() -> None:
+    svc = StriveService()
+    source_repo = MagicMock()
+    saved_source: Any = type(
+        "Source",
+        (),
+        {
+            "id": 42,
+            "student_pid": 7,
+            "activity_id": 3,
+            "filename": "notes.pdf",
+            "content_type": "application/pdf",
+            "created_at": datetime(2026, 4, 20, tzinfo=timezone.utc),
+            "pdf_bytes": b"%PDF-1.4 test",
+        },
+    )()
+    source_repo.get_by_id.return_value = saved_source
+    svc.source_repo = source_repo  # type: ignore[assignment]
+    subject = cast(User, type("U", (), {"pid": 7})())
+
+    with (
+        patch.object(svc, "extract_study_material_from_pdf", return_value={"text": "X"}),
+        patch.object(svc, "_generate_questions_with_llm", side_effect=RuntimeError("LLM down")),
+    ):
+        result = svc.generate_quiz_from_source(subject=subject, source_id=42, question_count=2)
+
+    assert result["question_count"] == 2
+    assert len(result["questions"]) == 2
+    for q in result["questions"]:
+        assert "saved source" in q["text"]


### PR DESCRIPTION
### Description
This PR replaces the temporary file storage for the uploaded sources with real database persistence. Students can also refresh the page and still see their previously uploaded sources and use them to generate quizzes without re-uploading. 

### Major Changes
- New database table (StriveSource) to store the uploaded pdfs and their metadata
- StriveSourceRepository that handles saving the files and querying them by student profile
- Service updates for generate_quiz_from_pdf, generate_quiz_from_source, and list_uploaded_sources to save the files to the database and allow re-generation from refreshed sources
- Two new API endpoints, GET/ sources and POST /sources/{source_id}/quizzes
- Frontend updates to show previous sources

### Testing
- Unit tests for StriveSourceRepository that covers create and list operations.
- Update service tests to test new methods
- Update router-edge case tests to cover new endpoints
- Frontend spec files for listSources and createSourceQuiz

### Future Considerations
- Let users deselect sources
- Add boundaries for uploaded files (file size limits)